### PR TITLE
  Enhanced tab bar badge API and fix oversized raster icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ CNButton.icon(
 
 ### Badge Support
 
-Display notification badges on tab bar items (iOS only):
+Display notification badges on tab bar items (iOS only). Badges are rendered as custom `UIView` overlays — they do not use `UITabBarItem.badgeValue`, so they support full color customization and consistent behavior across all supported iOS versions.
 
 ```dart
 CNTabBar(
@@ -651,16 +651,60 @@ CNTabBar(
     CNTabBarItem(
       label: 'Home',
       icon: CNSymbol('house.fill'),
-      badge: '3', // Red badge with "3"
+      hasBadge: true,
+      badgeText: '3', // Badge with "3"
+      badgeColor: Colors.blue, // Custom badge color
     ),
     CNTabBarItem(
       label: 'Messages',
       icon: CNSymbol('message.fill'),
-      badge: '12',
+      hasBadge: true,
+      badgeText: '12',
+      badgeColor: Colors.orange,
+    ),
+    CNTabBarItem(
+      label: 'Notifications',
+      icon: CNSymbol('bell.fill'),
+      hasBadge: true, // Small circular indicator (no badgeText)
+      badgeColor: Colors.green,
     ),
   ],
   currentIndex: _tabIndex,
   onTap: (i) => setState(() => _tabIndex = i),
+)
+```
+
+#### Badge Features:
+- **Simple Badge Control**: Use `hasBadge: true` to show a badge indicator
+- **Text Badges**: Add `badgeText` to show text/numbers in the badge
+- **Empty Badge Indicators**: Omit `badgeText` (or leave it empty) to show a small circular dot indicator
+- **Custom Badge Colors**: Use `badgeColor` to set any badge background color
+- **Automatic Fallback**: If `badgeColor` is not specified, the badge defaults to system red
+
+#### Badge Examples:
+```dart
+// Text badge
+CNTabBarItem(
+label: 'Messages',
+icon: CNSymbol('message.fill'),
+hasBadge: true,
+badgeText: '5',
+badgeColor: Colors.red,
+)
+
+// Empty circular indicator
+CNTabBarItem(
+label: 'Notifications',
+icon: CNSymbol('bell.fill'),
+hasBadge: true, // No badgeText = small dot
+badgeColor: Colors.green,
+)
+
+// No badge
+CNTabBarItem(
+label: 'Settings',
+icon: CNSymbol('gearshape.fill'),
+hasBadge: false, // Or omit entirely (default)
 )
 ```
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -6,15 +6,12 @@ PODS:
     - Flutter
     - SVGKit (~> 3.0)
   - Flutter (1.0.0)
-  - integration_test (0.0.1):
-    - Flutter
   - SVGKit (3.0.0):
     - CocoaLumberjack (~> 3.0)
 
 DEPENDENCIES:
   - cupertino_native_plus (from `.symlinks/plugins/cupertino_native_plus/ios`)
   - Flutter (from `Flutter`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/cupertino_native_plus/ios"
   Flutter:
     :path: Flutter
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 5644158777912b7de7469fa881f8a3f259c2512a
   cupertino_native_plus: d86c2d22e15e85fe4ee351662e47b5f20f422144
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   SVGKit: 1ad7513f8c74d9652f94ed64ddecda1a23864dea
 
 PODFILE CHECKSUM: e30f02f9d1c72c47bb6344a0a748c9d268180865

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		B90498BA069343E0D344D3FD /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08B2BFF013BE5EF94A81C3E3 /* Pods_Runner.framework */; };
 		CC5B6DC894AC20FADFC1CA39 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EDE1E60A6204FD0DE431907 /* Pods_RunnerTests.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 		A7EE84387F249B34074AA1D2 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		CCA40A6A6C97B3A349A01AB3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		EE4EA684D0FEB246ACF3E32B /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				B90498BA069343E0D344D3FD /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -120,6 +123,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -187,6 +191,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -212,6 +219,9 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -725,6 +735,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/example/lib/demos/tab_bar.dart
+++ b/example/lib/demos/tab_bar.dart
@@ -57,69 +57,77 @@ class _TabBarDemoPageState extends State<TabBarDemoPage>
             child: CNTabBar(
               items: _useAlternateIcons
                   ? [
-                      // Alternate SVG icons to test setState
-                      CNTabBarItem(
-                        label: 'Home',
-                        imageAsset: CNImageAsset('assets/icons/profile.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/profile-filled.svg',
-                        ),
-                        badge: '5',
-                      ),
-                      CNTabBarItem(
-                        label: 'Search',
-                        imageAsset: CNImageAsset('assets/icons/chat.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/chat-filled.svg',
-                        ),
-                        badge: '8',
-                      ),
-                      CNTabBarItem(
-                        label: 'Profile',
-                        imageAsset: CNImageAsset('assets/icons/home.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/home_filled.svg',
-                        ),
-                      ),
-                      CNTabBarItem(
-                        imageAsset: CNImageAsset('assets/icons/search.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/search-filled.svg',
-                        ),
-                      ),
-                    ]
+                // Alternate SVG icons to test setState
+                CNTabBarItem(
+                  label: 'Home',
+                  imageAsset: CNImageAsset('assets/icons/profile.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/profile-filled.svg',
+                  ),
+                  hasBadge: true,
+                  badgeText: '5',
+                  badgeColor: Colors.orange,
+                ),
+                CNTabBarItem(
+                  label: 'Search',
+                  imageAsset: CNImageAsset('assets/icons/chat.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/chat-filled.svg',
+                  ),
+                  hasBadge: true,
+                  badgeColor: Colors.green,
+                ),
+                CNTabBarItem(
+                  label: 'Profile',
+                  imageAsset: CNImageAsset('assets/icons/home.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/home_filled.svg',
+                  ),
+                ),
+                CNTabBarItem(
+                  imageAsset: CNImageAsset('assets/icons/search.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/search-filled.svg',
+                  ),
+                ),
+              ]
                   : [
-                      // Original SVG icons
-                      CNTabBarItem(
-                        label: 'Home',
-                        imageAsset: CNImageAsset('assets/icons/home.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/home_filled.svg',
-                        ),
-                        badge: '3',
-                      ),
-                      CNTabBarItem(
-                        label: 'Search',
-                        imageAsset: CNImageAsset('assets/icons/search.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/search-filled.svg',
-                        ),
-                        badge: '12',
-                      ),
-                      CNTabBarItem(
-                        label: 'Profile',
-                        imageAsset: CNImageAsset('assets/icons/profile.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/profile-filled.svg',
-                        ),
-                      ),
-                      CNTabBarItem(
-                        imageAsset: CNImageAsset('assets/icons/chat.svg'),
-                        activeImageAsset: CNImageAsset(
-                          'assets/icons/chat-filled.svg',
-                        ),
-                      ),
-                    ],
+                // Original SVG icons
+                CNTabBarItem(
+                  label: 'Home',
+                  imageAsset: CNImageAsset('assets/icons/home.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/home_filled.svg',
+                  ),
+                  hasBadge: true,
+                  badgeText: '3',
+                  badgeColor: Colors.blue,
+                ),
+                CNTabBarItem(
+                  label: 'Search',
+                  imageAsset: CNImageAsset('assets/icons/search.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/search-filled.svg',
+                  ),
+                  hasBadge: true,
+                  badgeText: '12',
+                ),
+                CNTabBarItem(
+                  label: 'Profile',
+                  imageAsset: CNImageAsset('assets/icons/profile.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/profile-filled.svg',
+                  ),
+                  hasBadge: true,
+                  badgeColor: Colors.purple,
+                ),
+                CNTabBarItem(
+                  imageAsset: CNImageAsset('assets/icons/chat.svg'),
+                  activeImageAsset: CNImageAsset(
+                    'assets/icons/chat-filled.svg',
+                  ),
+                ),
+              ],
               currentIndex: _index,
               split: true,
               rightCount: 1,
@@ -145,7 +153,7 @@ class _TabBarDemoPageState extends State<TabBarDemoPage>
               child: Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemBlue.withOpacity(0.8),
+                  color: CupertinoColors.systemBlue.withValues(alpha: 0.8),
                   borderRadius: BorderRadius.circular(25),
                 ),
                 child: Icon(

--- a/example/lib/demos/tab_bar.dart
+++ b/example/lib/demos/tab_bar.dart
@@ -188,7 +188,7 @@ class _ImageTabPage extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: CupertinoColors.black..withOpacity(0.2),
+              color: CupertinoColors.black.withOpacity(0.2),
               borderRadius: BorderRadius.circular(12),
             ),
             margin: const EdgeInsets.only(top: 12),

--- a/example/lib/demos/tab_bar.dart
+++ b/example/lib/demos/tab_bar.dart
@@ -153,7 +153,7 @@ class _TabBarDemoPageState extends State<TabBarDemoPage>
               child: Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemBlue.withValues(alpha: 0.8),
+                  color: CupertinoColors.systemBlue.withOpacity(0.8),
                   borderRadius: BorderRadius.circular(25),
                 ),
                 child: Icon(
@@ -188,7 +188,7 @@ class _ImageTabPage extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: CupertinoColors.black.withValues(alpha: 0.2),
+              color: CupertinoColors.black..withOpacity(0.2),
               borderRadius: BorderRadius.circular(12),
             ),
             margin: const EdgeInsets.only(top: 12),

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import cupertino_native
+import cupertino_native_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   CupertinoNativePlugin.register(with: registry.registrar(forPlugin: "CupertinoNativePlugin"))

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   fake_async:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/ios/Classes/Utils/ImageUtils.swift
+++ b/ios/Classes/Utils/ImageUtils.swift
@@ -122,7 +122,13 @@ final class ImageUtils {
       image = SVGImageLoader.shared.loadSVG(from: assetPath, size: svgSize)
     } else {
       // Use UIImage for raster images (PNG, JPG, etc.)
-      image = UIImage(contentsOfFile: path)
+      let raw = UIImage(contentsOfFile: path)
+      // Scale to target size if specified; avoids oversized icons when PNG pixel dimensions exceed tab bar limits
+      if let targetSize = size, let img = raw {
+        image = scaleImage(img, to: targetSize, scale: scale)
+      } else {
+        image = raw
+      }
     }
     
     // Apply tinting if color is provided
@@ -160,7 +166,13 @@ final class ImageUtils {
       image = SVGImageLoader.shared.loadSVG(from: data, size: svgSize)
     } else {
       // Try as raster image
-      image = UIImage(data: data, scale: scale)
+      let raw = UIImage(data: data, scale: scale)
+      // Scale to target size if specified; avoids oversized icons when PNG pixel dimensions exceed tab bar limits
+      if let targetSize = size, let img = raw {
+        image = scaleImage(img, to: targetSize, scale: scale)
+      } else {
+        image = raw
+      }
     }
     
     // Apply tinting if color is provided

--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -828,8 +828,7 @@ channel.setMethodCallHandler { [weak self] call, result in
       badgeView.isUserInteractionEnabled = false
       badgeView.layer.zPosition = 999
       let rawColor = (globalIndex < currentBadgeColors.count ? currentBadgeColors[globalIndex] : nil)
-      let color = (rawColor ?? UIColor.systemRed).withAlphaComponent(1.0)
-      badgeView.backgroundColor = color
+      badgeView.backgroundColor = rawColor ?? UIColor.systemRed
       badgeView.layer.masksToBounds = true
       badgeView.layer.borderWidth = 0
       bar.clipsToBounds = false

--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -16,6 +16,9 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
   private var currentSymbols: [String] = []
   private var currentActiveSymbols: [String] = []
   private var currentBadges: [String] = []
+  private var currentHasBadgeFlags: [Bool] = []
+  private var currentBadgeColors: [UIColor?] = []
+  private static let badgeViewTagBase = 0xC0FFEE
   private var currentCustomIconBytes: [Data?] = []
   private var currentActiveCustomIconBytes: [Data?] = []
   private var currentImageAssetPaths: [String] = []
@@ -37,6 +40,8 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     var symbols: [String] = []
     var activeSymbols: [String] = []
     var badges: [String] = []
+    var hasBadgeFlags: [Bool] = []
+    var badgeColors: [UIColor?] = []
     var customIconBytes: [Data?] = []
     var activeCustomIconBytes: [Data?] = []
     var imageAssetPaths: [String] = []
@@ -62,6 +67,8 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
       symbols = (dict["sfSymbols"] as? [String]) ?? []
       activeSymbols = (dict["activeSfSymbols"] as? [String]) ?? []
       badges = (dict["badges"] as? [String]) ?? []
+      hasBadgeFlags = (dict["hasBadgeFlags"] as? [Bool]) ?? []
+      badgeColors = Self.parseUIColorArray(dict["badgeColors"])
       if let bytesArray = dict["customIconBytes"] as? [FlutterStandardTypedData?] {
         customIconBytes = bytesArray.map { $0?.data }
       }
@@ -143,9 +150,6 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
         
         let title = (i < labels.count && !labels[i].isEmpty) ? labels[i] : nil
         let item = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
-        if i < badges.count && !badges[i].isEmpty {
-          item.badgeValue = badges[i]
-        }
         items.append(item)
       }
       return items
@@ -286,6 +290,8 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     self.currentSymbols = symbols
     self.currentActiveSymbols = activeSymbols
     self.currentBadges = badges
+    self.currentHasBadgeFlags = hasBadgeFlags
+    self.currentBadgeColors = badgeColors
     self.currentCustomIconBytes = customIconBytes
     self.currentActiveCustomIconBytes = activeCustomIconBytes
     self.currentImageAssetPaths = imageAssetPaths
@@ -313,6 +319,8 @@ channel.setMethodCallHandler { [weak self] call, result in
           let symbols = (args["sfSymbols"] as? [String]) ?? []
           let activeSymbols = (args["activeSfSymbols"] as? [String]) ?? []
           let badges = (args["badges"] as? [String]) ?? []
+          let hasBadgeFlags = (args["hasBadgeFlags"] as? [Bool]) ?? []
+          let badgeColors = Self.parseUIColorArray(args["badgeColors"])
           var customIconBytes: [Data?] = []
           var activeCustomIconBytes: [Data?] = []
           var imageAssetPaths: [String] = []
@@ -345,6 +353,8 @@ channel.setMethodCallHandler { [weak self] call, result in
           self.currentSymbols = symbols
           self.currentActiveSymbols = activeSymbols
           self.currentBadges = badges
+          self.currentHasBadgeFlags = hasBadgeFlags
+          self.currentBadgeColors = badgeColors
           self.currentCustomIconBytes = customIconBytes
           self.currentActiveCustomIconBytes = activeCustomIconBytes
           self.currentImageAssetPaths = imageAssetPaths
@@ -386,9 +396,6 @@ channel.setMethodCallHandler { [weak self] call, result in
               
               let title = (i < labels.count && !labels[i].isEmpty) ? labels[i] : nil
               let item = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
-              if i < badges.count && !badges[i].isEmpty {
-                item.badgeValue = badges[i]
-              }
               items.append(item)
             }
             return items
@@ -403,10 +410,12 @@ channel.setMethodCallHandler { [weak self] call, result in
               let idx = selectedIndex - leftEnd
               if idx >= 0 && idx < items.count { right.selectedItem = items[idx]; left.selectedItem = nil }
             }
+            self.scheduleBadgeLayout()
             result(nil)
           } else if let bar = self.tabBar {
             bar.items = buildItems(0..<count)
             if let items = bar.items, selectedIndex >= 0, selectedIndex < items.count { bar.selectedItem = items[selectedIndex] }
+            self.scheduleBadgeLayout()
             result(nil)
           } else {
             result(FlutterError(code: "state_error", message: "Tab bars not initialized", details: nil))
@@ -474,9 +483,6 @@ channel.setMethodCallHandler { [weak self] call, result in
               
               let title = (i < labels.count && !labels[i].isEmpty) ? labels[i] : nil
               let item = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
-              if i < badges.count && !badges[i].isEmpty {
-                item.badgeValue = badges[i]
-              }
               items.append(item)
             }
             return items
@@ -594,6 +600,7 @@ channel.setMethodCallHandler { [weak self] call, result in
             }
           }
           self.isSplit = split; self.rightCountVal = rightCount; self.leftInsetVal = leftInset; self.rightInsetVal = rightInset
+          self.scheduleBadgeLayout()
           result(nil)
         } else { result(FlutterError(code: "bad_args", message: "Missing layout", details: nil)) }
       case "setSelectedIndex":
@@ -748,6 +755,128 @@ channel.setMethodCallHandler { [weak self] call, result in
         result(FlutterMethodNotImplemented)
       }
     }
+    scheduleBadgeLayout()
+  }
+
+  // MARK: - Badge Helpers
+
+  private static func parseUIColorArray(_ raw: Any?) -> [UIColor?] {
+    if raw == nil { return [] }
+    if let arr = raw as? [Any?] {
+      return arr.map { v in
+        if v == nil || v is NSNull { return nil }
+        if let n = v as? NSNumber { return Self.colorFromARGB(n.intValue) }
+        return nil
+      }
+    }
+    if let arr = raw as? [Any] {
+      return arr.map { v in
+        if v is NSNull { return nil }
+        if let n = v as? NSNumber { return Self.colorFromARGB(n.intValue) }
+        return nil
+      }
+    }
+    return []
+  }
+
+  private func isBlankBadgeText(_ text: String) -> Bool {
+    return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  /// Returns the best-guess icon frame for a given slot index.
+  private func iconAnchor(forSlot slot: Int, in bar: UITabBar, count: Int) -> CGRect {
+    guard count > 0 else { return bar.bounds }
+    let barWidth = bar.bounds.width
+    let slotWidth = barWidth / CGFloat(count)
+    let slotX = slotWidth * CGFloat(slot)
+    let slotRect = CGRect(x: slotX, y: 0, width: slotWidth, height: bar.bounds.height)
+    func findImageView(_ view: UIView) -> UIImageView? {
+      for sub in view.subviews {
+        let frame = sub.convert(sub.bounds, to: bar)
+        if frame.intersects(slotRect) {
+          if let iv = sub as? UIImageView, iv.bounds.width > 5 { return iv }
+          if let iv = findImageView(sub) { return iv }
+        }
+      }
+      return nil
+    }
+    if let iv = findImageView(bar) { return iv.convert(iv.bounds, to: bar) }
+    let topY = bar.bounds.height * 0.12
+    let iconH = bar.bounds.height * 0.4
+    return CGRect(x: slotX, y: topY, width: slotWidth, height: iconH)
+  }
+
+  private func applyBadges(to bar: UITabBar, itemOffset: Int) {
+    let count = bar.items?.count ?? 0
+    guard count > 0 else { return }
+    for localIndex in 0..<count {
+      let globalIndex = itemOffset + localIndex
+      let tag = Self.badgeViewTagBase + globalIndex
+      let existing = bar.viewWithTag(tag)
+      let shouldShow = globalIndex < currentHasBadgeFlags.count && currentHasBadgeFlags[globalIndex]
+      let badgeText = (globalIndex < currentBadges.count) ? currentBadges[globalIndex] : ""
+      let hasText = shouldShow && !isBlankBadgeText(badgeText)
+      let wantsDotOnly = shouldShow && !hasText
+
+      if !shouldShow {
+        existing?.removeFromSuperview()
+        continue
+      }
+
+      let badgeView = existing ?? UIView(frame: .zero)
+      badgeView.tag = tag
+      badgeView.isUserInteractionEnabled = false
+      badgeView.layer.zPosition = 999
+      let rawColor = (globalIndex < currentBadgeColors.count ? currentBadgeColors[globalIndex] : nil)
+      let color = (rawColor ?? UIColor.systemRed).withAlphaComponent(1.0)
+      badgeView.backgroundColor = color
+      badgeView.layer.masksToBounds = true
+      badgeView.layer.borderWidth = 0
+      bar.clipsToBounds = false
+      let anchor = iconAnchor(forSlot: localIndex, in: bar, count: count)
+
+      if wantsDotOnly {
+        let size: CGFloat = 10.0
+        badgeView.layer.cornerRadius = size / 2
+        badgeView.subviews.forEach { $0.removeFromSuperview() }
+        if badgeView.superview == nil { bar.addSubview(badgeView) }
+        bar.bringSubviewToFront(badgeView)
+        badgeView.frame = CGRect(x: anchor.maxX - size / 2, y: anchor.minY - size / 2 + 4, width: size, height: size)
+      } else if hasText {
+        let label: UILabel = (badgeView.subviews.compactMap { $0 as? UILabel }.first) ?? UILabel(frame: .zero)
+        if label.superview == nil { badgeView.addSubview(label) }
+        label.text = badgeText
+        label.textColor = .white
+        label.font = UIFont.systemFont(ofSize: 11, weight: .semibold)
+        label.textAlignment = .center
+        label.sizeToFit()
+        let h: CGFloat = 18
+        let padX: CGFloat = 6
+        let w = max(h, label.bounds.width + padX * 2)
+        badgeView.layer.cornerRadius = h / 2
+        label.frame = CGRect(x: (w - label.bounds.width) / 2, y: (h - label.bounds.height) / 2, width: label.bounds.width, height: label.bounds.height)
+        if badgeView.superview == nil { bar.addSubview(badgeView) }
+        bar.bringSubviewToFront(badgeView)
+        badgeView.frame = CGRect(x: anchor.maxX - w / 2, y: anchor.minY - h / 2 + 4, width: w, height: h)
+      }
+    }
+  }
+
+  private func scheduleBadgeLayout() {
+    let apply = { [weak self] in
+      guard let self = self else { return }
+      if let bar = self.tabBar {
+        bar.layoutIfNeeded()
+        self.applyBadges(to: bar, itemOffset: 0)
+      }
+      if let left = self.tabBarLeft, let right = self.tabBarRight {
+        left.layoutIfNeeded(); right.layoutIfNeeded()
+        self.applyBadges(to: left, itemOffset: 0)
+        self.applyBadges(to: right, itemOffset: left.items?.count ?? 0)
+      }
+    }
+    DispatchQueue.main.async(execute: apply)
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: apply)
   }
 
   func view() -> UIView { container }

--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -31,6 +31,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
   private var leftInsetVal: CGFloat = 0
   private var rightInsetVal: CGFloat = 0
   private var splitSpacingVal: CGFloat = 12 // Apple's recommended spacing for visual separation
+  private var currentIconSizes: [CGFloat] = [] // Track icon sizes for dynamic height calculation
 
   init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(name: "CupertinoNativeTabBar_\(viewId)", binaryMessenger: messenger)
@@ -51,7 +52,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     var imageAssetFormats: [String] = []
     var activeImageAssetFormats: [String] = []
     var iconScale: CGFloat = UIScreen.main.scale
-    var sizes: [NSNumber] = [] // ignored; use system metrics
+    var sizes: [NSNumber?] = []
     var colors: [NSNumber] = [] // ignored; use tintColor
     var selectedIndex: Int = 0
     var isDark: Bool = false
@@ -88,7 +89,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
       if let scale = dict["iconScale"] as? NSNumber {
         iconScale = CGFloat(truncating: scale)
       }
-      sizes = (dict["sfSymbolSizes"] as? [NSNumber]) ?? []
+      sizes = (dict["sfSymbolSizes"] as? [NSNumber?]) ?? []
       colors = (dict["sfSymbolColors"] as? [NSNumber]) ?? []
       if let v = dict["selectedIndex"] as? NSNumber { selectedIndex = v.intValue }
       if let v = dict["isDark"] as? NSNumber { isDark = v.boolValue }
@@ -122,34 +123,55 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
       for i in range {
         var image: UIImage? = nil
         var selectedImage: UIImage? = nil
-        
+
+        // Extract size for this item from sizes array
+        let imgSize: CGSize? = (i < sizes.count) ? sizes[i].flatMap { $0.doubleValue > 0 ? CGSize(width: $0.doubleValue, height: $0.doubleValue) : nil } : nil
+
         // Priority: imageAsset > customIconBytes > SF Symbol
         // Unselected image
         if i < imageAssetData.count, let data = imageAssetData[i] {
-          image = Self.createImageFromData(data, format: (i < imageAssetFormats.count) ? imageAssetFormats[i] : nil, scale: iconScale)
+          image = Self.createImageFromData(data, format: (i < imageAssetFormats.count) ? imageAssetFormats[i] : nil, scale: iconScale, size: imgSize)
         } else if i < imageAssetPaths.count && !imageAssetPaths[i].isEmpty {
-          image = Self.loadFlutterAsset(imageAssetPaths[i])
+          image = Self.loadFlutterAsset(imageAssetPaths[i], size: imgSize)
         } else if i < customIconBytes.count, let data = customIconBytes[i] {
           image = UIImage(data: data, scale: self.iconScale)?.withRenderingMode(.alwaysTemplate)
         } else if i < symbols.count && !symbols[i].isEmpty {
-          image = UIImage(systemName: symbols[i])
+          // Apply size configuration if specified
+          if i < sizes.count, let sizeNum = sizes[i], sizeNum.doubleValue > 0 {
+            let config = UIImage.SymbolConfiguration(pointSize: CGFloat(sizeNum.doubleValue))
+            image = UIImage(systemName: symbols[i], withConfiguration: config)
+          } else {
+            image = UIImage(systemName: symbols[i])
+          }
         }
         
         // Selected image: Use active versions if available
         if i < activeImageAssetData.count, let data = activeImageAssetData[i] {
-          selectedImage = Self.createImageFromData(data, format: (i < activeImageAssetFormats.count) ? activeImageAssetFormats[i] : nil, scale: iconScale)
+          selectedImage = Self.createImageFromData(data, format: (i < activeImageAssetFormats.count) ? activeImageAssetFormats[i] : nil, scale: iconScale, size: imgSize)
         } else if i < activeImageAssetPaths.count && !activeImageAssetPaths[i].isEmpty {
-          selectedImage = Self.loadFlutterAsset(activeImageAssetPaths[i])
+          selectedImage = Self.loadFlutterAsset(activeImageAssetPaths[i], size: imgSize)
         } else if i < activeCustomIconBytes.count, let data = activeCustomIconBytes[i] {
           selectedImage = UIImage(data: data, scale: self.iconScale)?.withRenderingMode(.alwaysTemplate)
         } else if i < activeSymbols.count && !activeSymbols[i].isEmpty {
-          selectedImage = UIImage(systemName: activeSymbols[i])
+          // Apply size configuration if specified
+          if i < sizes.count, let sizeNum = sizes[i], sizeNum.doubleValue > 0 {
+            let config = UIImage.SymbolConfiguration(pointSize: CGFloat(sizeNum.doubleValue))
+            selectedImage = UIImage(systemName: activeSymbols[i], withConfiguration: config)
+          } else {
+            selectedImage = UIImage(systemName: activeSymbols[i])
+          }
         } else {
           selectedImage = image // Fallback to same image
         }
         
         let title = (i < labels.count && !labels[i].isEmpty) ? labels[i] : nil
         let item = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
+        // Adjust title position for larger icons to prevent overlap
+        // Default icon size is ~25pt
+        if i < sizes.count, let sizeNum = sizes[i], sizeNum.doubleValue > 25 {
+          let offset = CGFloat(sizeNum.doubleValue - 25)
+          item.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: offset)
+        }
         items.append(item)
       }
       return items
@@ -303,13 +325,19 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     self.iconScale = iconScale
     self.leftInsetVal = leftInset
     self.rightInsetVal = rightInset
+    self.currentIconSizes = sizes.compactMap { $0 }.map { CGFloat(truncating: $0) }
 channel.setMethodCallHandler { [weak self] call, result in
       guard let self = self else { result(nil); return }
       switch call.method {
       case "getIntrinsicSize":
         if let bar = self.tabBar ?? self.tabBarLeft ?? self.tabBarRight {
           let size = bar.sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
-          result(["width": Double(size.width), "height": Double(size.height)])
+          // Adjust height for larger icons - default icon is ~25pt, default height is ~49pt
+          let defaultIconSize: CGFloat = 25.0
+          let maxIconSize = self.currentIconSizes.max() ?? defaultIconSize
+          let extraHeight = max(0, maxIconSize - defaultIconSize)
+          let dynamicHeight = size.height + extraHeight
+          result(["width": Double(size.width), "height": Double(dynamicHeight)])
         } else {
           result(["width": Double(self.container.bounds.width), "height": 50.0])
         }
@@ -329,6 +357,7 @@ channel.setMethodCallHandler { [weak self] call, result in
           var activeImageAssetData: [Data?] = []
           var imageAssetFormats: [String] = []
           var activeImageAssetFormats: [String] = []
+          let sizes = (args["sfSymbolSizes"] as? [NSNumber?]) ?? []
           if let bytesArray = args["customIconBytes"] as? [FlutterStandardTypedData?] {
             customIconBytes = bytesArray.map { $0?.data }
           }
@@ -363,39 +392,64 @@ channel.setMethodCallHandler { [weak self] call, result in
           self.currentActiveImageAssetData = activeImageAssetData
           self.currentImageAssetFormats = imageAssetFormats
           self.currentActiveImageAssetFormats = activeImageAssetFormats
+          // Store icon sizes for dynamic height calculation
+          self.currentIconSizes = sizes.compactMap { $0?.doubleValue }.map { CGFloat($0) }
           func buildItems(_ range: Range<Int>) -> [UITabBarItem] {
             var items: [UITabBarItem] = []
             for i in range {
               var image: UIImage? = nil
               var selectedImage: UIImage? = nil
-              
+
+              // Extract size for this item from sizes array
+              let imgSize: CGSize? = (i < sizes.count) ? sizes[i].flatMap { $0.doubleValue > 0 ? CGSize(width: $0.doubleValue, height: $0.doubleValue) : nil } : nil
+
               // Priority: imageAsset > customIconBytes > SF Symbol
               // Unselected image
               if i < imageAssetData.count, let data = imageAssetData[i] {
-                image = Self.createImageFromData(data, format: (i < imageAssetFormats.count) ? imageAssetFormats[i] : nil, scale: self.iconScale)
+                image = Self.createImageFromData(data, format: (i < imageAssetFormats.count) ? imageAssetFormats[i] : nil, scale: self.iconScale, size: imgSize)
               } else if i < imageAssetPaths.count && !imageAssetPaths[i].isEmpty {
-                image = Self.loadFlutterAsset(imageAssetPaths[i])
+                image = Self.loadFlutterAsset(imageAssetPaths[i], size: imgSize)
               } else if i < customIconBytes.count, let data = customIconBytes[i] {
                 image = UIImage(data: data, scale: self.iconScale)?.withRenderingMode(.alwaysTemplate)
               } else if i < symbols.count && !symbols[i].isEmpty {
-                image = UIImage(systemName: symbols[i])
+                // Apply size configuration if specified
+                if i < sizes.count, let sizeNum = sizes[i], sizeNum.doubleValue > 0 {
+                  let config = UIImage.SymbolConfiguration(pointSize: CGFloat(sizeNum.doubleValue))
+                  image = UIImage(systemName: symbols[i], withConfiguration: config)
+                } else {
+                  image = UIImage(systemName: symbols[i])
+                }
               }
-              
+
               // Selected image: Use active versions if available
               if i < activeImageAssetData.count, let data = activeImageAssetData[i] {
-                selectedImage = Self.createImageFromData(data, format: (i < activeImageAssetFormats.count) ? activeImageAssetFormats[i] : nil, scale: self.iconScale)
+                selectedImage = Self.createImageFromData(data, format: (i < activeImageAssetFormats.count) ? activeImageAssetFormats[i] : nil, scale: self.iconScale, size: imgSize)
               } else if i < activeImageAssetPaths.count && !activeImageAssetPaths[i].isEmpty {
-                selectedImage = Self.loadFlutterAsset(activeImageAssetPaths[i])
+                selectedImage = Self.loadFlutterAsset(activeImageAssetPaths[i], size: imgSize)
               } else if i < activeCustomIconBytes.count, let data = activeCustomIconBytes[i] {
                 selectedImage = UIImage(data: data, scale: self.iconScale)?.withRenderingMode(.alwaysTemplate)
               } else if i < activeSymbols.count && !activeSymbols[i].isEmpty {
-                selectedImage = UIImage(systemName: activeSymbols[i])
+                // Apply size configuration if specified
+                if i < sizes.count, let sizeNum = sizes[i], sizeNum.doubleValue > 0 {
+                  let config = UIImage.SymbolConfiguration(pointSize: CGFloat(sizeNum.doubleValue))
+                  selectedImage = UIImage(systemName: activeSymbols[i], withConfiguration: config)
+                } else {
+                  selectedImage = UIImage(systemName: activeSymbols[i])
+                }
               } else {
                 selectedImage = image // Fallback to same image
               }
-              
+
               let title = (i < labels.count && !labels[i].isEmpty) ? labels[i] : nil
               let item = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
+              // Adjust title position for larger icons to prevent overlap
+              if i < sizes.count, let sizeNum = sizes[i] {
+                let pointSize = sizeNum.doubleValue
+                if pointSize > 25 {
+                  let offset = CGFloat(pointSize - 25)
+                  item.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: offset)
+                }
+              }
               items.append(item)
             }
             return items
@@ -450,33 +504,49 @@ channel.setMethodCallHandler { [weak self] call, result in
             if #available(iOS 13.0, *) { let ap = UITabBarAppearance(); ap.configureWithDefaultBackground(); return ap }
             return nil
           }()
+          let iconSizes = self.currentIconSizes
           func buildItems(_ range: Range<Int>) -> [UITabBarItem] {
             var items: [UITabBarItem] = []
             for i in range {
               var image: UIImage? = nil
               var selectedImage: UIImage? = nil
-              
+
+              // Extract size for this item from stored icon sizes
+              let imgSize: CGSize? = (i < iconSizes.count && iconSizes[i] > 0) ? CGSize(width: iconSizes[i], height: iconSizes[i]) : nil
+
               // Priority: imageAsset > customIconBytes > SF Symbol
               // Unselected image
               if i < imageAssetData.count, let data = imageAssetData[i] {
-                image = Self.createImageFromData(data, format: (i < imageAssetFormats.count) ? imageAssetFormats[i] : nil, scale: self.iconScale)
+                image = Self.createImageFromData(data, format: (i < imageAssetFormats.count) ? imageAssetFormats[i] : nil, scale: self.iconScale, size: imgSize)
               } else if i < imageAssetPaths.count && !imageAssetPaths[i].isEmpty {
-                image = Self.loadFlutterAsset(imageAssetPaths[i])
+                image = Self.loadFlutterAsset(imageAssetPaths[i], size: imgSize)
               } else if i < customIconBytes.count, let data = customIconBytes[i] {
                 image = UIImage(data: data, scale: self.iconScale)?.withRenderingMode(.alwaysTemplate)
               } else if i < symbols.count && !symbols[i].isEmpty {
-                image = UIImage(systemName: symbols[i])
+                // Apply size configuration if stored
+                if i < iconSizes.count && iconSizes[i] > 0 {
+                  let config = UIImage.SymbolConfiguration(pointSize: iconSizes[i])
+                  image = UIImage(systemName: symbols[i], withConfiguration: config)
+                } else {
+                  image = UIImage(systemName: symbols[i])
+                }
               }
-              
+
               // Selected image: Use active versions if available
               if i < activeImageAssetData.count, let data = activeImageAssetData[i] {
-                selectedImage = Self.createImageFromData(data, format: (i < activeImageAssetFormats.count) ? activeImageAssetFormats[i] : nil, scale: self.iconScale)
+                selectedImage = Self.createImageFromData(data, format: (i < activeImageAssetFormats.count) ? activeImageAssetFormats[i] : nil, scale: self.iconScale, size: imgSize)
               } else if i < activeImageAssetPaths.count && !activeImageAssetPaths[i].isEmpty {
-                selectedImage = Self.loadFlutterAsset(activeImageAssetPaths[i])
+                selectedImage = Self.loadFlutterAsset(activeImageAssetPaths[i], size: imgSize)
               } else if i < activeCustomIconBytes.count, let data = activeCustomIconBytes[i] {
                 selectedImage = UIImage(data: data, scale: self.iconScale)?.withRenderingMode(.alwaysTemplate)
               } else if i < activeSymbols.count && !activeSymbols[i].isEmpty {
-                selectedImage = UIImage(systemName: activeSymbols[i])
+                // Apply size configuration if stored
+                if i < iconSizes.count && iconSizes[i] > 0 {
+                  let config = UIImage.SymbolConfiguration(pointSize: iconSizes[i])
+                  selectedImage = UIImage(systemName: activeSymbols[i], withConfiguration: config)
+                } else {
+                  selectedImage = UIImage(systemName: activeSymbols[i])
+                }
               } else {
                 selectedImage = image // Fallback to same image
               }
@@ -906,12 +976,12 @@ channel.setMethodCallHandler { [weak self] call, result in
     return ImageUtils.colorFromARGB(argb)
   }
 
-  private static func loadFlutterAsset(_ assetPath: String) -> UIImage? {
-    return ImageUtils.loadFlutterAsset(assetPath)
+  private static func loadFlutterAsset(_ assetPath: String, size: CGSize? = nil) -> UIImage? {
+    return ImageUtils.loadFlutterAsset(assetPath, size: size)
   }
 
-  private static func createImageFromData(_ data: Data, format: String?, scale: CGFloat) -> UIImage? {
-    return ImageUtils.createImageFromData(data, format: format, scale: scale)
+  private static func createImageFromData(_ data: Data, format: String?, scale: CGFloat, size: CGSize? = nil) -> UIImage? {
+    return ImageUtils.createImageFromData(data, format: format, size: size, scale: scale)
   }
 
 }

--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -32,6 +32,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
   private var rightInsetVal: CGFloat = 0
   private var splitSpacingVal: CGFloat = 12 // Apple's recommended spacing for visual separation
   private var currentIconSizes: [CGFloat] = [] // Track icon sizes for dynamic height calculation
+  private var containerBoundsObservation: NSKeyValueObservation?
 
   init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(name: "CupertinoNativeTabBar_\(viewId)", binaryMessenger: messenger)
@@ -113,6 +114,14 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
 
     container.backgroundColor = .clear
     if #available(iOS 13.0, *) { container.overrideUserInterfaceStyle = isDark ? .dark : .light }
+
+    containerBoundsObservation = container.observe(\.bounds, options: [.old, .new]) { [weak self] _, change in
+      guard let self = self else { return }
+      let oldWidth = change.oldValue?.width ?? 0
+      let newWidth = change.newValue?.width ?? 0
+      guard newWidth > 0, oldWidth != newWidth else { return }
+      self.scheduleBadgeLayout()
+    }
 
     let appearance: UITabBarAppearance? = {
     if #available(iOS 13.0, *) { let ap = UITabBarAppearance(); ap.configureWithDefaultBackground(); return ap }
@@ -326,7 +335,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     self.leftInsetVal = leftInset
     self.rightInsetVal = rightInset
     self.currentIconSizes = sizes.compactMap { $0 }.map { CGFloat(truncating: $0) }
-channel.setMethodCallHandler { [weak self] call, result in
+    channel.setMethodCallHandler { [weak self] call, result in
       guard let self = self else { result(nil); return }
       switch call.method {
       case "getIntrinsicSize":
@@ -879,6 +888,7 @@ channel.setMethodCallHandler { [weak self] call, result in
   private func applyBadges(to bar: UITabBar, itemOffset: Int) {
     let count = bar.items?.count ?? 0
     guard count > 0 else { return }
+    guard bar.bounds.width > 0 else { return }
     for localIndex in 0..<count {
       let globalIndex = itemOffset + localIndex
       let tag = Self.badgeViewTagBase + globalIndex
@@ -934,6 +944,8 @@ channel.setMethodCallHandler { [weak self] call, result in
   private func scheduleBadgeLayout() {
     let apply = { [weak self] in
       guard let self = self else { return }
+      self.container.setNeedsLayout()
+      self.container.layoutIfNeeded()
       if let bar = self.tabBar {
         bar.layoutIfNeeded()
         self.applyBadges(to: bar, itemOffset: 0)

--- a/lib/components/button.dart
+++ b/lib/components/button.dart
@@ -1104,7 +1104,7 @@ class _CNButtonState extends State<CNButton> {
         return _effectiveTint;
       case CNButtonStyle.glass:
         // For iOS < 26, approximate glass with tinted appearance
-        return _effectiveTint?.withValues(alpha: 0.1);
+        return _effectiveTint?.withOpacity(0.1);
       default:
         return null;
     }
@@ -1117,7 +1117,7 @@ class _CNButtonState extends State<CNButton> {
       case CNButtonStyle.prominentGlass:
         return _effectiveTint ?? Theme.of(context).primaryColor;
       case CNButtonStyle.glass:
-        return Theme.of(context).primaryColor.withValues(alpha: 0.1);
+        return Theme.of(context).primaryColor.withOpacity(0.1);
       default:
         return Colors.transparent;
     }

--- a/lib/components/button.dart
+++ b/lib/components/button.dart
@@ -378,19 +378,10 @@ class _CNButtonState extends State<CNButton> {
       if (widget.config.imagePadding != null)
         'imagePadding': widget.config.imagePadding,
       if (effectivePadding != null) ...{
-        if (effectivePadding.top != 0.0) 'paddingTop': effectivePadding.top,
-        if (effectivePadding.bottom != 0.0)
-          'paddingBottom': effectivePadding.bottom,
-        if (effectivePadding.left != 0.0) 'paddingLeft': effectivePadding.left,
-        if (effectivePadding.right != 0.0)
-          'paddingRight': effectivePadding.right,
-        // Support horizontal/vertical as convenience
-        if (effectivePadding.left == effectivePadding.right &&
-            effectivePadding.left != 0.0)
-          'paddingHorizontal': effectivePadding.left,
-        if (effectivePadding.top == effectivePadding.bottom &&
-            effectivePadding.top != 0.0)
-          'paddingVertical': effectivePadding.top,
+        'paddingTop': effectivePadding.top,
+        'paddingBottom': effectivePadding.bottom,
+        'paddingLeft': effectivePadding.left,
+        'paddingRight': effectivePadding.right,
       },
       if (widget.config.borderRadius != null)
         'borderRadius': widget.config.borderRadius,

--- a/lib/components/glass_button_group.dart
+++ b/lib/components/glass_button_group.dart
@@ -401,21 +401,10 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
       if (button.config.borderRadius != null)
         'borderRadius': button.config.borderRadius,
       if (button.config.padding != null) ...{
-        if (button.config.padding!.top != 0.0)
-          'paddingTop': button.config.padding!.top,
-        if (button.config.padding!.bottom != 0.0)
-          'paddingBottom': button.config.padding!.bottom,
-        if (button.config.padding!.left != 0.0)
-          'paddingLeft': button.config.padding!.left,
-        if (button.config.padding!.right != 0.0)
-          'paddingRight': button.config.padding!.right,
-        // Support horizontal/vertical as convenience
-        if (button.config.padding!.left == button.config.padding!.right &&
-            button.config.padding!.left != 0.0)
-          'paddingHorizontal': button.config.padding!.left,
-        if (button.config.padding!.top == button.config.padding!.bottom &&
-            button.config.padding!.top != 0.0)
-          'paddingVertical': button.config.padding!.top,
+        'paddingTop': button.config.padding!.top,
+        'paddingBottom': button.config.padding!.bottom,
+        'paddingLeft': button.config.padding!.left,
+        'paddingRight': button.config.padding!.right,
       },
       if (button.config.minHeight != null) 'minHeight': button.config.minHeight,
       if (button.config.imagePadding != null)

--- a/lib/components/glass_button_group.dart
+++ b/lib/components/glass_button_group.dart
@@ -55,6 +55,7 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
   Axis? _lastAxis;
   double? _lastSpacing;
   double? _lastSpacingForGlass;
+  Future<List<Map<String, dynamic>>>? _buttonsFuture;
 
   @override
   void didUpdateWidget(covariant CNGlassButtonGroup oldWidget) {
@@ -82,11 +83,12 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
   Widget _buildNativeGroup(BuildContext context) {
     const viewType = 'CupertinoNativeGlassButtonGroup';
 
-    // Convert buttons to maps asynchronously if needed
+    _buttonsFuture ??= Future.wait(
+      widget.buttons.map((button) => _buttonToMapAsync(button, context)),
+    );
+
     return FutureBuilder<List<Map<String, dynamic>>>(
-      future: Future.wait(
-        widget.buttons.map((button) => _buttonToMapAsync(button, context)),
-      ),
+      future: _buttonsFuture,
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const SizedBox.shrink();

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -15,7 +15,9 @@ class CNTabBarItem {
     this.label,
     this.icon,
     this.activeIcon,
-    this.badge,
+    this.hasBadge = false,
+    this.badgeText,
+    this.badgeColor,
     this.customIcon,
     this.activeCustomIcon,
     this.imageAsset,
@@ -33,10 +35,15 @@ class CNTabBarItem {
   /// If not provided, [icon] is used for both states.
   final CNSymbol? activeIcon;
 
-  /// Optional badge text to display on the tab bar item.
-  /// On iOS, this displays as a red badge with the text.
-  /// On macOS, badges are not supported by NSSegmentedControl.
-  final String? badge;
+  /// Whether to show a badge on this item. Has no effect on macOS.
+  final bool hasBadge;
+
+  /// Text to display inside the badge. When null or empty and [hasBadge] is
+  /// true, a small circular dot indicator is shown instead.
+  final String? badgeText;
+
+  /// Badge background color. Defaults to system red when null.
+  final Color? badgeColor;
 
   /// Optional custom icon for unselected state.
   /// Use icons from CupertinoIcons, Icons, or any custom IconData.
@@ -84,17 +91,17 @@ class CNTabBar extends StatefulWidget {
     this.rightCount = 1,
     this.shrinkCentered = true,
     this.splitSpacing =
-        12.0, // Apple's recommended spacing for visual separation
+    12.0, // Apple's recommended spacing for visual separation
   }) : assert(items.length >= 2, 'Tab bar must have at least 2 items'),
-       assert(
-         items.length <= 5,
-         'Tab bar should have 5 or fewer items for optimal usability',
-       ),
-       assert(rightCount >= 1, 'Right count must be at least 1'),
-       assert(
-         rightCount < items.length,
-         'Right count must be less than total items',
-       );
+        assert(
+        items.length <= 5,
+        'Tab bar should have 5 or fewer items for optimal usability',
+        ),
+        assert(rightCount >= 1, 'Right count must be at least 1'),
+        assert(
+        rightCount < items.length,
+        'Right count must be less than total items',
+        );
 
   /// Items to display in the tab bar.
   final List<CNTabBarItem> items;
@@ -152,6 +159,8 @@ class _CNTabBarState extends State<CNTabBar> {
   List<String>? _lastSymbols;
   List<String>? _lastActiveSymbols;
   List<String>? _lastBadges;
+  List<bool>? _lastHasBadgeFlags;
+  List<int?>? _lastBadgeColors;
   bool? _lastSplit;
   int? _lastRightCount;
   double? _lastSplitSpacing;
@@ -177,7 +186,7 @@ class _CNTabBarState extends State<CNTabBar> {
     // Check if we should use native platform view
     final isIOSOrMacOS =
         defaultTargetPlatform == TargetPlatform.iOS ||
-        defaultTargetPlatform == TargetPlatform.macOS;
+            defaultTargetPlatform == TargetPlatform.macOS;
     final shouldUseNative =
         isIOSOrMacOS && PlatformVersion.shouldUseNativeGlass;
 
@@ -272,37 +281,41 @@ class _CNTabBarState extends State<CNTabBar> {
   }
 
   Future<Widget> _buildNativeTabBar(
-    BuildContext context, {
-    required List<Uint8List?> customIconBytes,
-    required List<Uint8List?> activeCustomIconBytes,
-  }) async {
+      BuildContext context, {
+        required List<Uint8List?> customIconBytes,
+        required List<Uint8List?> activeCustomIconBytes,
+      }) async {
     final labels = widget.items.map((e) => e.label ?? '').toList();
     final symbols = widget.items.map((e) => e.icon?.name ?? '').toList();
     final activeSymbols = widget.items
         .map((e) => e.activeIcon?.name ?? e.icon?.name ?? '')
         .toList();
-    final badges = widget.items.map((e) => e.badge ?? '').toList();
+    final badges = widget.items.map((e) => e.badgeText ?? '').toList();
+    final hasBadgeFlags = widget.items.map((e) => e.hasBadge).toList();
+    final badgeColors = widget.items
+        .map((e) => resolveColorToArgb(e.badgeColor, context))
+        .toList();
     final sizes = widget.items
         .map((e) => (widget.iconSize ?? e.icon?.size ?? e.imageAsset?.size))
         .toList();
     final colors = widget.items
         .map(
           (e) =>
-              resolveColorToArgb(e.icon?.color ?? e.imageAsset?.color, context),
-        )
+          resolveColorToArgb(e.icon?.color ?? e.imageAsset?.color, context),
+    )
         .toList();
 
     // Extract imageAsset data and resolve asset paths based on device pixel ratio
     final imageAssetPaths = await Future.wait(
       widget.items.map(
-        (e) async => e.imageAsset != null
+            (e) async => e.imageAsset != null
             ? await resolveAssetPathForPixelRatio(e.imageAsset!.assetPath)
             : '',
       ),
     );
     final activeImageAssetPaths = await Future.wait(
       widget.items.map(
-        (e) async => e.activeImageAsset != null
+            (e) async => e.activeImageAsset != null
             ? await resolveAssetPathForPixelRatio(e.activeImageAsset!.assetPath)
             : '',
       ),
@@ -340,6 +353,8 @@ class _CNTabBarState extends State<CNTabBar> {
       'sfSymbols': symbols,
       'activeSfSymbols': activeSymbols,
       'badges': badges,
+      'hasBadgeFlags': hasBadgeFlags,
+      'badgeColors': badgeColors,
       'customIconBytes': customIconBytes,
       'activeCustomIconBytes': activeCustomIconBytes,
       'imageAssetPaths': imageAssetPaths,
@@ -369,17 +384,17 @@ class _CNTabBarState extends State<CNTabBar> {
     final viewType = 'CupertinoNativeTabBar';
     final platformView = defaultTargetPlatform == TargetPlatform.iOS
         ? UiKitView(
-            viewType: viewType,
-            creationParams: creationParams,
-            creationParamsCodec: const StandardMessageCodec(),
-            onPlatformViewCreated: _onCreated,
-          )
+      viewType: viewType,
+      creationParams: creationParams,
+      creationParamsCodec: const StandardMessageCodec(),
+      onPlatformViewCreated: _onCreated,
+    )
         : AppKitView(
-            viewType: viewType,
-            creationParams: creationParams,
-            creationParamsCodec: const StandardMessageCodec(),
-            onPlatformViewCreated: _onCreated,
-          );
+      viewType: viewType,
+      creationParams: creationParams,
+      creationParamsCodec: const StandardMessageCodec(),
+      onPlatformViewCreated: _onCreated,
+    );
 
     final h = widget.height ?? _intrinsicHeight ?? 50.0;
     if (!widget.split && widget.shrinkCentered) {
@@ -463,13 +478,21 @@ class _CNTabBarState extends State<CNTabBar> {
     final activeSymbols = widget.items
         .map((e) => e.activeIcon?.name ?? e.icon?.name ?? '')
         .toList();
-    final badges = widget.items.map((e) => e.badge ?? '').toList();
+    final badges = widget.items.map((e) => e.badgeText ?? '').toList();
+    final hasBadgeFlags = widget.items.map((e) => e.hasBadge).toList();
+    final badgeColors = widget.items
+        .map((e) => resolveColorToArgb(e.badgeColor, context))
+        .toList();
 
     // Check if basic properties changed
     if (_lastLabels?.join('|') != labels.join('|') ||
         _lastSymbols?.join('|') != symbols.join('|') ||
         _lastActiveSymbols?.join('|') != activeSymbols.join('|') ||
-        _lastBadges?.join('|') != badges.join('|')) {
+        _lastBadges?.join('|') != badges.join('|') ||
+        _lastHasBadgeFlags?.map((e) => e.toString()).join('|') !=
+            hasBadgeFlags.map((e) => e.toString()).join('|') ||
+        _lastBadgeColors?.map((e) => e?.toString() ?? '').join('|') !=
+            badgeColors.map((e) => e?.toString() ?? '').join('|')) {
       // Re-render custom icons if items changed
       final iconBytes = await _renderCustomIcons();
       final customIconBytes = iconBytes[0];
@@ -492,24 +515,24 @@ class _CNTabBarState extends State<CNTabBar> {
       final imageAssetFormats = widget.items
           .map(
             (e) =>
-                e.imageAsset?.imageFormat ??
-                detectImageFormat(
-                  e.imageAsset?.assetPath,
-                  e.imageAsset?.imageData,
-                ) ??
-                '',
-          )
+        e.imageAsset?.imageFormat ??
+            detectImageFormat(
+              e.imageAsset?.assetPath,
+              e.imageAsset?.imageData,
+            ) ??
+            '',
+      )
           .toList();
       final activeImageAssetFormats = widget.items
           .map(
             (e) =>
-                e.activeImageAsset?.imageFormat ??
-                detectImageFormat(
-                  e.activeImageAsset?.assetPath,
-                  e.activeImageAsset?.imageData,
-                ) ??
-                '',
-          )
+        e.activeImageAsset?.imageFormat ??
+            detectImageFormat(
+              e.activeImageAsset?.assetPath,
+              e.activeImageAsset?.imageData,
+            ) ??
+            '',
+      )
           .toList();
 
       await ch.invokeMethod('setItems', {
@@ -517,6 +540,8 @@ class _CNTabBarState extends State<CNTabBar> {
         'sfSymbols': symbols,
         'activeSfSymbols': activeSymbols,
         'badges': badges,
+        'hasBadgeFlags': hasBadgeFlags,
+        'badgeColors': badgeColors,
         'customIconBytes': customIconBytes,
         'activeCustomIconBytes': activeCustomIconBytes,
         'imageAssetPaths': imageAssetPaths,
@@ -532,6 +557,8 @@ class _CNTabBarState extends State<CNTabBar> {
       _lastSymbols = symbols;
       _lastActiveSymbols = activeSymbols;
       _lastBadges = badges;
+      _lastHasBadgeFlags = hasBadgeFlags;
+      _lastBadgeColors = badgeColors;
       // Re-measure width in case content changed
       _requestIntrinsicSize();
     }
@@ -576,7 +603,11 @@ class _CNTabBarState extends State<CNTabBar> {
     _lastActiveSymbols = widget.items
         .map((e) => e.activeIcon?.name ?? e.icon?.name ?? '')
         .toList();
-    _lastBadges = widget.items.map((e) => e.badge ?? '').toList();
+    _lastBadges = widget.items.map((e) => e.badgeText ?? '').toList();
+    _lastHasBadgeFlags = widget.items.map((e) => e.hasBadge).toList();
+    _lastBadgeColors = widget.items
+        .map((e) => resolveColorToArgb(e.badgeColor, context))
+        .toList();
     // Note: Custom icon bytes are cached in _syncPropsToNativeIfNeeded when rendered
   }
 

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -305,48 +305,41 @@ class _CNTabBarState extends State<CNTabBar> {
     )
         .toList();
 
-    // Extract imageAsset data and resolve asset paths based on device pixel ratio
-    final imageAssetPaths = await Future.wait(
-      widget.items.map(
-            (e) async => e.imageAsset != null
-            ? await resolveAssetPathForPixelRatio(e.imageAsset!.assetPath)
-            : '',
-      ),
-    );
-    final activeImageAssetPaths = await Future.wait(
-      widget.items.map(
-            (e) async => e.activeImageAsset != null
-            ? await resolveAssetPathForPixelRatio(e.activeImageAsset!.assetPath)
-            : '',
-      ),
-    );
+    // Use raw asset paths (no pixel-ratio resolution) so iOS loads them with
+    // the correct iconScale and scales to the target size. Resolving to @3x
+    // paths causes UIImage(contentsOfFile:) to load at scale 1.0, making
+    // icons appear 3× too large on high-density displays.
+    final imageAssetPaths = widget.items
+        .map((e) => e.imageAsset?.assetPath ?? '')
+        .toList();
+    final activeImageAssetPaths = widget.items
+        .map((e) => e.activeImageAsset?.assetPath ?? '')
+        .toList();
     final imageAssetData = widget.items
         .map((e) => e.imageAsset?.imageData)
         .toList();
     final activeImageAssetData = widget.items
         .map((e) => e.activeImageAsset?.imageData)
         .toList();
-    // Auto-detect format if not provided (use resolved paths)
-    final imageAssetFormats = await Future.wait(
-      widget.items.asMap().entries.map((entry) async {
-        final e = entry.value;
-        if (e.imageAsset == null) return '';
-        final resolvedPath = imageAssetPaths[entry.key];
-        return e.imageAsset!.imageFormat ??
-            detectImageFormat(resolvedPath, e.imageAsset!.imageData) ??
-            '';
-      }),
-    );
-    final activeImageAssetFormats = await Future.wait(
-      widget.items.asMap().entries.map((entry) async {
-        final e = entry.value;
-        if (e.activeImageAsset == null) return '';
-        final resolvedPath = activeImageAssetPaths[entry.key];
-        return e.activeImageAsset!.imageFormat ??
-            detectImageFormat(resolvedPath, e.activeImageAsset!.imageData) ??
-            '';
-      }),
-    );
+    final imageAssetFormats = widget.items
+        .map(
+          (e) =>
+          e.imageAsset?.imageFormat ??
+              detectImageFormat(e.imageAsset?.assetPath, e.imageAsset?.imageData) ??
+              '',
+    )
+        .toList();
+    final activeImageAssetFormats = widget.items
+        .map(
+          (e) =>
+          e.activeImageAsset?.imageFormat ??
+              detectImageFormat(
+                e.activeImageAsset?.assetPath,
+                e.activeImageAsset?.imageData,
+              ) ??
+              '',
+    )
+        .toList();
 
     final creationParams = <String, dynamic>{
       'labels': labels,

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -534,6 +534,9 @@ class _CNTabBarState extends State<CNTabBar> {
             '',
       )
           .toList();
+      final sizes = widget.items
+          .map((e) => (widget.iconSize ?? e.icon?.size ?? e.imageAsset?.size))
+          .toList();
 
       await ch.invokeMethod('setItems', {
         'labels': labels,
@@ -550,6 +553,7 @@ class _CNTabBarState extends State<CNTabBar> {
         'activeImageAssetData': activeImageAssetData,
         'imageAssetFormats': imageAssetFormats,
         'activeImageAssetFormats': activeImageAssetFormats,
+        'sfSymbolSizes': sizes,
         'iconScale': iconScale,
         'selectedIndex': widget.currentIndex,
       });


### PR DESCRIPTION
## Badge API                                                                                                       
                                                            
  Replaces `badge: String?` with three explicit fields on `CNTabBarItem`:

  - `hasBadge: bool` — controls whether a badge is shown
  - `badgeText: String?` — text inside badge; when null and `hasBadge` is true, shows a dot indicator
  - `badgeColor: Color?` — badge background color; defaults to system red when null

  Badges are rendered as custom overlay `UIView`s (replacing `UITabBarItem.badgeValue`) to support arbitrary colors
  and dot-only indicators.

  ### Migration

  ```dart
  // Before
  CNTabBarItem(badge: '5')
  CNTabBarItem(badge: '')  // hacky dot

  // After
  CNTabBarItem(hasBadge: true, badgeText: '5')
  CNTabBarItem(hasBadge: true)  // clean dot badge

  macOS is unaffected — hasBadge has no effect on macOS, matching existing behavior.

  Icon Size Fixes

  - Raster images now respect target size: UIImage(contentsOfFile:) loaded PNG/JPG at raw pixel dimensions as points,
   making icons appear oversized. Native code now scales raster images to the specified size, consistent with how
  SVGs are handled.
  - Init and update paths now consistent: _buildNativeTabBar previously resolved asset paths to @3x variants via
  resolveAssetPathForPixelRatio. iOS loaded those without applying the @3x scale, causing icons to appear 3× too
  large on high-density displays. Both paths now use raw asset paths, matching setItems behavior.
  - Sizes propagated on item updates: sfSymbolSizes was missing from the setItems channel call, so icon sizes were
  lost on dynamic updates (badge changes, setState).
