### PR TITLE
0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@
 - **Split tab bar default selection**: Fixed an issue where the rightmost item appeared visually selected alongside the current tab when using `split: true` with `rightCount: 1`. The root cause was UITabBar resetting `selectedItem` during item re-assignment for label rendering, with the final layout pass missing selection restoration.
 - **Non-split tab bar selection after layout**: Fixed the same item re-assignment selection loss in non-split tab bar mode.
 - **PlatformException on iOS hot restart**: Added `PlatformViewGuard` that delays platform-view creation by 500 ms on startup, preventing `PlatformException(recreating_view)` crashes when the Flutter engine hasn't fully purged stale view registrations from a previous Dart isolate. All native components (`CNIconView`, `LiquidGlassContainer`, `CNTabBar`) now show Flutter fallbacks during this brief window.
-- **iOS platform view cleanup**: Added `deinit` to `CupertinoTabBarPlatformView` and `CupertinoTabBarSearchPlatformView` to properly clear method channel handlers, nullify delegates, and remove views from the hierarchy on deallocation.
+- **iOS platform view cleanup**: Added `deinit` to all platform views (`CupertinoTabBarPlatformView`, `CupertinoTabBarSearchPlatformView`, `LiquidGlassContainerView`, `LiquidTextPlatformView`, `FloatingIslandPlatformView`, `CupertinoSearchBarPlatformView`) to properly clear method channel handlers and remove views from the hierarchy on deallocation.
+
+### Performance
+
+- **Stable platform view keys**: Added `UniqueKey` to all components (`CNButton`, `CNIconView`, `CNSlider`, `CNSwitch`, `CNSegmentedControl`, `CNPopupMenuButton`, `CNGlassButtonGroup`, `CNFloatingIsland`, `CNSearchBar`, `CNSearchScaffold`) to prevent Flutter from destroying and recreating native views on parent rebuilds. Previously, any parent `setState` could trigger full native view recreation causing incomplete rendering.
+- **Cached FutureBuilder futures**: `CNGlassButtonGroup` and `CNIconView` now cache their async creation futures and only rebuild them when source data actually changes, preventing platform view flicker on rebuilds.
+- **SwiftUI ObservableObject pattern**: `LiquidGlassContainer` and `CNLiquidText` iOS views now use `@ObservedObject` view models instead of replacing `hostingController.rootView` on every config update. This lets SwiftUI diff and update only changed properties, preserving animations and avoiding full view tree recreation.
+- **Lightweight `splitRightAsButton` sync**: Toggling `splitRightAsButton` now uses a dedicated `setSplitRightAsButton` method channel call instead of triggering a full `setLayout` rebuild that destroys and recreates all tab bar instances.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.0.8
+
+### Features
+
+- **`splitRightAsButton`**: New `CNTabBar` property that makes right-side split items act as plain buttons instead of selectable tabs. When enabled, tapping right items fires `onTap` without changing the visual selection — selection is controlled solely by `currentIndex`. Useful for action buttons like settings or compose that shouldn't participate in tab selection.
+
+### Bug fixes
+
+- **Split tab bar default selection**: Fixed an issue where the rightmost item appeared visually selected alongside the current tab when using `split: true` with `rightCount: 1`. The root cause was UITabBar resetting `selectedItem` during item re-assignment for label rendering, with the final layout pass missing selection restoration.
+- **Non-split tab bar selection after layout**: Fixed the same item re-assignment selection loss in non-split tab bar mode.
+- **PlatformException on iOS hot restart**: Added `PlatformViewGuard` that delays platform-view creation by 500 ms on startup, preventing `PlatformException(recreating_view)` crashes when the Flutter engine hasn't fully purged stale view registrations from a previous Dart isolate. All native components (`CNIconView`, `LiquidGlassContainer`, `CNTabBar`) now show Flutter fallbacks during this brief window.
+- **iOS platform view cleanup**: Added `deinit` to `CupertinoTabBarPlatformView` and `CupertinoTabBarSearchPlatformView` to properly clear method channel handlers, nullify delegates, and remove views from the hierarchy on deallocation.
+
+---
+
 ## 0.0.7
 
 **cupertino_native_plus** — native Liquid Glass and Cupertino-style controls for iOS and macOS via platform views. This release ships the current public API, unified icon handling, and documentation. See [MIGRATION.md](MIGRATION.md) for breaking changes.

--- a/README.md
+++ b/README.md
@@ -218,13 +218,26 @@ CNTabBar(
       icon: const CNIcon.symbol('person.crop.circle'),
       activeIcon: const CNIcon.symbol('person.crop.circle.fill'),
     ),
+    CNTabBarItem(
+      label: 'Settings',
+      icon: const CNIcon.symbol('gear'),
+    ),
   ],
   currentIndex: _selectedIndex,
-  onTap: (index) => setState(() => _selectedIndex = index),
+  onTap: (index) {
+    if (index == 2) {
+      openSettings(); // Right item acts as a button
+    } else {
+      setState(() => _selectedIndex = index);
+    }
+  },
   split: true, // Separates tabs when scrolling
   rightCount: 1, // Number of tabs pinned to the right
+  splitRightAsButton: true, // Right items act as buttons, not tabs
 )
 ```
+
+When `splitRightAsButton` is `true`, the right-side items behave as plain buttons: tapping them fires `onTap` but does not change the visual selection. Selection is controlled solely by `currentIndex`.
 
 ### Native iOS 26 Tab Bar (CNTabBarNative)
 
@@ -312,7 +325,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  cupertino_native_plus: ^0.0.7
+  cupertino_native_plus: ^0.0.8
 ```
 
 ## Usage
@@ -571,7 +584,7 @@ print('macOS version: ${PlatformVersion.macOSVersion}');
 
 ## Migration from Previous Versions
 
-Version 0.0.7 introduces **breaking changes** to the icon/image API. See [MIGRATION.md](MIGRATION.md) for the full guide.
+Version 0.0.8 is a non-breaking update. Version 0.0.7 introduced **breaking changes** to the icon/image API. See [MIGRATION.md](MIGRATION.md) for the full guide.
 
 ### Quick Reference
 
@@ -587,7 +600,7 @@ Version 0.0.7 introduces **breaking changes** to the icon/image API. See [MIGRAT
 
 ```yaml
 dependencies:
-  cupertino_native_plus: ^0.0.7
+  cupertino_native_plus: ^0.0.8
 ```
 
 ## Contributing

--- a/example/lib/demos/tab_bar.dart
+++ b/example/lib/demos/tab_bar.dart
@@ -14,6 +14,7 @@ class _TabBarDemoPageState extends State<TabBarDemoPage>
   late final TabController _controller;
   int _index = 0;
   bool _useAlternateIcons = false;
+  bool _splitRightAsButton = false;
 
   // Label style state
   int _labelStyleIndex = 0; // 0 = default, 1 = bold+large, 2 = Georgia italic
@@ -154,10 +155,30 @@ class _TabBarDemoPageState extends State<TabBarDemoPage>
               rightCount: 1,
               splitSpacing: 8,
               shrinkCentered: true,
+              splitRightAsButton: _splitRightAsButton,
               tint: Colors.red,
               labelStyle: _labelStyle,
               activeLabelStyle: _activeLabelStyle,
               onTap: (i) {
+                if (_splitRightAsButton && i >= 3) {
+                  // Right item acts as a button — show an action instead of selecting
+                  showCupertinoDialog(
+                    context: context,
+                    builder: (_) => CupertinoAlertDialog(
+                      title: const Text('Button tapped'),
+                      content: const Text(
+                        'The right split item is acting as a button.',
+                      ),
+                      actions: [
+                        CupertinoDialogAction(
+                          child: const Text('OK'),
+                          onPressed: () => Navigator.pop(context),
+                        ),
+                      ],
+                    ),
+                  );
+                  return;
+                }
                 setState(() => _index = i);
                 _controller.animateTo(i);
               },
@@ -189,6 +210,29 @@ class _TabBarDemoPageState extends State<TabBarDemoPage>
                       _useAlternateIcons
                           ? CupertinoIcons.refresh
                           : CupertinoIcons.arrow_2_squarepath,
+                      color: CupertinoColors.white,
+                      size: 24,
+                    ),
+                  ),
+                ),
+                // Toggle splitRightAsButton
+                CupertinoButton(
+                  padding: EdgeInsets.zero,
+                  onPressed: () {
+                    setState(() {
+                      _splitRightAsButton = !_splitRightAsButton;
+                    });
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: _splitRightAsButton
+                          ? CupertinoColors.systemGreen.withValues(alpha: 0.8)
+                          : CupertinoColors.systemGrey.withValues(alpha: 0.8),
+                      borderRadius: BorderRadius.circular(25),
+                    ),
+                    child: const Icon(
+                      CupertinoIcons.hand_draw,
                       color: CupertinoColors.white,
                       size: 24,
                     ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.7"
+    version: "0.0.8"
   equatable:
     dependency: transitive
     description:

--- a/ios/Classes/Views/CupertinoSearchBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoSearchBarPlatformView.swift
@@ -137,6 +137,10 @@ class CupertinoSearchBarPlatformView: NSObject, FlutterPlatformView {
         }
     }
 
+    deinit {
+        channel.setMethodCallHandler(nil)
+    }
+
     func view() -> UIView {
         return container
     }

--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -579,6 +579,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
       }
     }
     // Store split settings for future updates
+    self.currentSelectedIndex = selectedIndex
     self.isSplit = split
     self.rightCountVal = rightCount
     self.currentLabels = labels
@@ -659,6 +660,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
             self.iconScale = CGFloat(truncating: scale)
           }
           let selectedIndex = (args["selectedIndex"] as? NSNumber)?.intValue ?? 0
+          self.currentSelectedIndex = selectedIndex
           self.currentLabels = labels
           self.currentSymbols = symbols
           self.currentActiveSymbols = activeSymbols
@@ -965,6 +967,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
               }
             }
           }
+          self.currentSelectedIndex = selectedIndex
           self.isSplit = split; self.rightCountVal = rightCount; self.leftInsetVal = leftInset; self.rightInsetVal = rightInset
           self.scheduleBadgeLayout()
           result(nil)
@@ -1190,14 +1193,21 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     // Split right
     if let right = tabBarRight, right === tabBar, let items = right.items, let idx = items.firstIndex(of: item), let left = tabBarLeft, let leftItems = left.items {
       if splitRightAsButton {
-        // Button mode: fire callback but restore previous selection
+        // Button mode: fire callback, then deselect right bar on next run loop
+        // (iOS 26 liquid glass ignores synchronous selectedItem = nil)
         channel.invokeMethod("valueChanged", arguments: ["index": leftItems.count + idx])
-        // Deselect right and restore left selection
         let prevIdx = self.currentSelectedIndex
-        if prevIdx < leftItems.count, prevIdx >= 0 {
-          right.selectedItem = nil
-          left.selectedItem = leftItems[prevIdx]
+        DispatchQueue.main.async { [weak self, weak right, weak left] in
+          guard let self = self else { return }
+          self.withSuppressedSelectionCallbacks {
+            right?.selectedItem = nil
+            if let left = left, let leftItems = left.items,
+               prevIdx >= 0, prevIdx < leftItems.count {
+              left.selectedItem = leftItems[prevIdx]
+            }
+          }
         }
+        return
       } else {
         tabBarLeft?.selectedItem = nil
         channel.invokeMethod("valueChanged", arguments: ["index": leftItems.count + idx])

--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -12,6 +12,8 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
   // MARK: - State Properties
   private var isSplit: Bool = false
   private var rightCountVal: Int = 1
+  private var splitRightAsButton: Bool = false
+  private var currentSelectedIndex: Int = 0
   private var currentLabels: [String] = []
   private var currentSymbols: [String] = []
   private var currentActiveSymbols: [String] = []
@@ -366,6 +368,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
       if let s = dict["split"] as? NSNumber { split = s.boolValue }
       if let rc = dict["rightCount"] as? NSNumber { rightCount = rc.intValue }
       if let sp = dict["splitSpacing"] as? NSNumber { splitSpacingVal = CGFloat(truncating: sp) }
+      if let rb = dict["splitRightAsButton"] as? NSNumber { self.splitRightAsButton = rb.boolValue }
       if let ls = dict["labelStyle"] as? [String: Any] { self.labelStyleDict = ls }
       if let als = dict["activeLabelStyle"] as? [String: Any] { self.activeLabelStyleDict = als }
       // content insets controlled by Flutter padding; keep zero here
@@ -758,6 +761,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
           let leftInset = self.leftInsetVal
           let rightInset = self.rightInsetVal
           if let sp = args["splitSpacing"] as? NSNumber { self.splitSpacingVal = CGFloat(truncating: sp) }
+          if let rb = args["splitRightAsButton"] as? NSNumber { self.splitRightAsButton = rb.boolValue }
           let selectedIndex = (args["selectedIndex"] as? NSNumber)?.intValue ?? 0
           // Remove existing bars
           self.tabBar?.removeFromSuperview(); self.tabBar = nil
@@ -853,11 +857,16 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
             if let ap = appearance { if #available(iOS 13.0, *) { left.standardAppearance = ap; right.standardAppearance = ap; if #available(iOS 15.0, *) { left.scrollEdgeAppearance = ap; right.scrollEdgeAppearance = ap } } }
             left.items = buildItems(0..<leftEnd)
             right.items = buildItems(leftEnd..<count)
-            if selectedIndex < leftEnd, let items = left.items { left.selectedItem = items[selectedIndex]; right.selectedItem = nil }
+            if self.splitRightAsButton {
+              // Button mode: right bar never shows selection; always select in left bar
+              right.selectedItem = nil
+              if selectedIndex < leftEnd, let items = left.items { left.selectedItem = items[selectedIndex] }
+            } else if selectedIndex < leftEnd, let items = left.items { left.selectedItem = items[selectedIndex]; right.selectedItem = nil }
             else if let items = right.items { let idx = selectedIndex - leftEnd; if idx >= 0 && idx < items.count { right.selectedItem = items[idx]; left.selectedItem = nil } }
             self.container.addSubview(left); self.container.addSubview(right)
             let capturedSelectedIndex = selectedIndex
             let capturedLeftEnd = leftEnd
+            let capturedButtonMode = self.splitRightAsButton
             DispatchQueue.main.async { [weak self, weak left, weak right] in
               guard let self = self, let left = left, let right = right else { return }
               self.activateSplitConstraintsIfNeeded(left: left, right: right, count: count, rightCount: rightCount, leftInset: leftInset, rightInset: rightInset)
@@ -873,7 +882,12 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
               left.items = leftItems
               right.items = rightItems
               // Restore selection after re-assigning items (re-assignment can reset selection)
-              if capturedSelectedIndex < capturedLeftEnd, let items = left.items, capturedSelectedIndex < items.count {
+              if capturedButtonMode {
+                right.selectedItem = nil
+                if capturedSelectedIndex < capturedLeftEnd, let items = left.items, capturedSelectedIndex < items.count {
+                  left.selectedItem = items[capturedSelectedIndex]
+                }
+              } else if capturedSelectedIndex < capturedLeftEnd, let items = left.items, capturedSelectedIndex < items.count {
                 left.selectedItem = items[capturedSelectedIndex]
                 right.selectedItem = nil
               } else if let items = right.items {
@@ -892,6 +906,22 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
                 left.layoutIfNeeded()
                 right.setNeedsLayout()
                 right.layoutIfNeeded()
+                // Restore selection again after final layout pass (layout can reset selection)
+                if capturedButtonMode {
+                  right.selectedItem = nil
+                  if capturedSelectedIndex < capturedLeftEnd, let items = left.items, capturedSelectedIndex < items.count {
+                    left.selectedItem = items[capturedSelectedIndex]
+                  }
+                } else if capturedSelectedIndex < capturedLeftEnd, let items = left.items, capturedSelectedIndex < items.count {
+                  left.selectedItem = items[capturedSelectedIndex]
+                  right.selectedItem = nil
+                } else if let items = right.items {
+                  let idx = capturedSelectedIndex - capturedLeftEnd
+                  if idx >= 0 && idx < items.count {
+                    right.selectedItem = items[idx]
+                    left.selectedItem = nil
+                  }
+                }
               }
             }
           } else {
@@ -920,8 +950,12 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
               bar.setNeedsLayout()
               bar.layoutIfNeeded()
               // Re-assign items to force label rendering
+              let savedSelected = bar.selectedItem
               let items = bar.items
               bar.items = items
+              // Restore selection after re-assigning items (re-assignment can reset selection)
+              if let saved = savedSelected { bar.selectedItem = saved }
+              else if let items = bar.items, selectedIndex >= 0, selectedIndex < items.count { bar.selectedItem = items[selectedIndex] }
               // Force another update cycle for text rendering
               DispatchQueue.main.async { [weak bar] in
                 guard let bar = bar else { return }
@@ -937,6 +971,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
         } else { result(FlutterError(code: "bad_args", message: "Missing layout", details: nil)) }
       case "setSelectedIndex":
         if let args = call.arguments as? [String: Any], let idx = (args["index"] as? NSNumber)?.intValue {
+          self.currentSelectedIndex = idx
           // Single bar
           if let bar = self.tabBar, let items = bar.items, idx >= 0, idx < items.count {
             withSuppressedSelectionCallbacks {
@@ -958,11 +993,16 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
             if let right = self.tabBarRight, let rightItems = right.items {
               let ridx = idx - leftItems.count
               if ridx >= 0, ridx < rightItems.count {
-                withSuppressedSelectionCallbacks {
-                  right.selectedItem = rightItems[ridx]
-                  self.tabBarLeft?.selectedItem = nil
+                if self.splitRightAsButton {
+                  // Button mode: don't visually select right items
+                  result(nil)
+                } else {
+                  withSuppressedSelectionCallbacks {
+                    right.selectedItem = rightItems[ridx]
+                    self.tabBarLeft?.selectedItem = nil
+                  }
+                  result(nil)
                 }
-                result(nil)
                 return
               }
             }
@@ -999,6 +1039,19 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
           self.scheduleBadgeLayout()
           result(nil)
         } else { result(FlutterError(code: "bad_args", message: "Missing badges", details: nil)) }
+      case "setSplitRightAsButton":
+        if let args = call.arguments as? [String: Any], let val = (args["value"] as? NSNumber)?.boolValue {
+          self.splitRightAsButton = val
+          // If turning on button mode, deselect right bar and restore left selection
+          if val, let right = self.tabBarRight, let left = self.tabBarLeft, let leftItems = left.items {
+            right.selectedItem = nil
+            let idx = self.currentSelectedIndex
+            if idx >= 0, idx < leftItems.count {
+              left.selectedItem = leftItems[idx]
+            }
+          }
+          result(nil)
+        } else { result(FlutterError(code: "bad_args", message: "Missing value", details: nil)) }
       case "refresh":
         // Force refresh for label rendering on iOS < 16
         // UITabBar only fully layouts labels when items are selected
@@ -1106,6 +1159,17 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     }
   }
 
+  deinit {
+    channel.setMethodCallHandler(nil)
+    tabBar?.delegate = nil
+    tabBarLeft?.delegate = nil
+    tabBarRight?.delegate = nil
+    tabBar?.removeFromSuperview()
+    tabBarLeft?.removeFromSuperview()
+    tabBarRight?.removeFromSuperview()
+    container.removeFromSuperview()
+  }
+
   func view() -> UIView { container }
 
   func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
@@ -1125,8 +1189,19 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     }
     // Split right
     if let right = tabBarRight, right === tabBar, let items = right.items, let idx = items.firstIndex(of: item), let left = tabBarLeft, let leftItems = left.items {
-      tabBarLeft?.selectedItem = nil
-      channel.invokeMethod("valueChanged", arguments: ["index": leftItems.count + idx])
+      if splitRightAsButton {
+        // Button mode: fire callback but restore previous selection
+        channel.invokeMethod("valueChanged", arguments: ["index": leftItems.count + idx])
+        // Deselect right and restore left selection
+        let prevIdx = self.currentSelectedIndex
+        if prevIdx < leftItems.count, prevIdx >= 0 {
+          right.selectedItem = nil
+          left.selectedItem = leftItems[prevIdx]
+        }
+      } else {
+        tabBarLeft?.selectedItem = nil
+        channel.invokeMethod("valueChanged", arguments: ["index": leftItems.count + idx])
+      }
       return
     }
   }

--- a/ios/Classes/Views/CupertinoTabBarSearchView.swift
+++ b/ios/Classes/Views/CupertinoTabBarSearchView.swift
@@ -310,6 +310,13 @@ class CupertinoTabBarSearchPlatformView: NSObject, FlutterPlatformView, UITabBar
         }
     }
 
+    deinit {
+        channel.setMethodCallHandler(nil)
+        tabBar?.delegate = nil
+        tabBar?.removeFromSuperview()
+        container.removeFromSuperview()
+    }
+
     func view() -> UIView {
         return container
     }

--- a/ios/Classes/Views/FloatingIslandPlatformView.swift
+++ b/ios/Classes/Views/FloatingIslandPlatformView.swift
@@ -133,6 +133,10 @@ class FloatingIslandPlatformView: NSObject, FlutterPlatformView {
         }
     }
 
+    deinit {
+        channel.setMethodCallHandler(nil)
+    }
+
     func view() -> UIView {
         return container
     }

--- a/ios/Classes/Views/LiquidGlassContainerView.swift
+++ b/ios/Classes/Views/LiquidGlassContainerView.swift
@@ -2,12 +2,42 @@ import Flutter
 import UIKit
 import SwiftUI
 
+// MARK: - ViewModel
+
+@available(iOS 26.0, *)
+final class LiquidGlassContainerViewModel: ObservableObject {
+  @Published var effect: String
+  @Published var shape: String
+  @Published var cornerRadius: CGFloat?
+  @Published var tint: UIColor?
+  @Published var interactive: Bool
+
+  init(effect: String, shape: String, cornerRadius: CGFloat?, tint: UIColor?, interactive: Bool) {
+    self.effect = effect
+    self.shape = shape
+    self.cornerRadius = cornerRadius
+    self.tint = tint
+    self.interactive = interactive
+  }
+
+  func apply(effect: String, shape: String, cornerRadius: CGFloat?, tint: UIColor?, interactive: Bool) {
+    self.effect = effect
+    self.shape = shape
+    self.cornerRadius = cornerRadius
+    self.tint = tint
+    self.interactive = interactive
+  }
+}
+
+// MARK: - Platform View (iOS 26+)
+
 @available(iOS 26.0, *)
 class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
   private let container: UIView
-  private var hostingController: UIHostingController<LiquidGlassContainerSwiftUI>
+  private let hostingController: UIHostingController<LiquidGlassContainerSwiftUI>
   private let channel: FlutterMethodChannel
-  
+  private let viewModel: LiquidGlassContainerViewModel
+
   init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(name: "\(ChannelConstants.viewIdCupertinoNativeLiquidGlassContainer)_\(viewId)", binaryMessenger: messenger)
     self.container = UIView(frame: frame)
@@ -17,26 +47,22 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
     let config = LiquidGlassContainerConfig.parse(from: args)
     let tint = config.tintARGB.map { ImageUtils.colorFromARGB($0) }
 
-    let glassView = LiquidGlassContainerSwiftUI(
+    let viewModel = LiquidGlassContainerViewModel(
       effect: config.effect,
       shape: config.shape,
       cornerRadius: config.cornerRadius,
       tint: tint,
       interactive: config.interactive
     )
-    
+    self.viewModel = viewModel
+
+    let glassView = LiquidGlassContainerSwiftUI(viewModel: viewModel)
     self.hostingController = UIHostingController(rootView: glassView)
     self.hostingController.view.backgroundColor = .clear
     self.hostingController.overrideUserInterfaceStyle = config.isDark ? .dark : .light
-    
+
     super.init()
-    
-    // Sync Flutter's brightness mode with Swift at initialization
-    if #available(iOS 13.0, *) {
-      self.hostingController.overrideUserInterfaceStyle = config.isDark ? .dark : .light
-    }
-    
-    // Add hosting controller as child
+
     container.addSubview(hostingController.view)
     hostingController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
@@ -45,8 +71,7 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
       hostingController.view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
       hostingController.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
     ])
-    
-    // Set up method channel handler
+
     channel.setMethodCallHandler { [weak self] (call, result) in
       if call.method == ChannelConstants.methodUpdateConfig {
         self?.updateConfig(args: call.arguments)
@@ -56,40 +81,35 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
       }
     }
   }
-  
+
+  deinit {
+    channel.setMethodCallHandler(nil)
+  }
+
   private func updateConfig(args: Any?) {
     let config = LiquidGlassContainerConfig.parse(from: args)
     let tint = config.tintARGB.map { ImageUtils.colorFromARGB($0) }
-    let newGlassView = LiquidGlassContainerSwiftUI(
-      effect: config.effect,
-      shape: config.shape,
-      cornerRadius: config.cornerRadius,
-      tint: tint,
-      interactive: config.interactive
-    )
-    hostingController.rootView = newGlassView
+    viewModel.apply(effect: config.effect, shape: config.shape, cornerRadius: config.cornerRadius, tint: tint, interactive: config.interactive)
     hostingController.overrideUserInterfaceStyle = config.isDark ? .dark : .light
   }
-  
+
   func view() -> UIView {
     return container
   }
 }
 
+// MARK: - SwiftUI View
+
 @available(iOS 26.0, *)
 struct LiquidGlassContainerSwiftUI: View {
-  let effect: String
-  let shape: String
-  let cornerRadius: CGFloat?
-  let tint: UIColor?
-  let interactive: Bool
-  
+  @ObservedObject var viewModel: LiquidGlassContainerViewModel
+
   var body: some View {
     GeometryReader { geometry in
       shapeForConfig()
         .fill(Color.clear)
         .contentShape(shapeForConfig())
-        .allowsHitTesting(interactive)  // Only intercept touches when interactive glass is enabled
+        .allowsHitTesting(viewModel.interactive)  // Only intercept touches when interactive glass is enabled
         .glassEffect(glassEffectForConfig(), in: shapeForConfig())
         .frame(width: geometry.size.width, height: geometry.size.height)
         .animation(.easeInOut(duration: 0.25), value: configIdentity)
@@ -98,28 +118,28 @@ struct LiquidGlassContainerSwiftUI: View {
 
   /// Single Equatable value for animation to avoid multiple animation pipelines (reduces jank).
   private var configIdentity: String {
-    "\(effect)|\(shape)|\(cornerRadius ?? -1)|\(interactive)"
+    "\(viewModel.effect)|\(viewModel.shape)|\(viewModel.cornerRadius ?? -1)|\(viewModel.interactive)"
   }
-  
+
   private func glassEffectForConfig() -> Glass {
     // Always use .regular for now - prominent glass API may be available in future
     var glass = Glass.regular
-    
-    if let tintColor = tint {
+
+    if let tintColor = viewModel.tint {
       glass = glass.tint(Color(tintColor))
     }
-    
-    if interactive {
+
+    if viewModel.interactive {
       glass = glass.interactive()
     }
-    
+
     return glass
   }
-  
+
   private func shapeForConfig() -> some Shape {
-    switch shape {
+    switch viewModel.shape {
     case "rect":
-      if let radius = cornerRadius {
+      if let radius = viewModel.cornerRadius {
         return AnyShape(RoundedRectangle(cornerRadius: radius))
       }
       return AnyShape(RoundedRectangle(cornerRadius: 0))
@@ -131,18 +151,18 @@ struct LiquidGlassContainerSwiftUI: View {
   }
 }
 
-// Fallback for iOS < 26
+// MARK: - Fallback (iOS < 26)
+
 class FallbackLiquidGlassContainerView: NSObject, FlutterPlatformView {
   private let container: UIView
-  
+
   init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.container = UIView(frame: frame)
     self.container.backgroundColor = .clear
     super.init()
   }
-  
+
   func view() -> UIView {
     return container
   }
 }
-

--- a/ios/Classes/Views/LiquidTextPlatformView.swift
+++ b/ios/Classes/Views/LiquidTextPlatformView.swift
@@ -74,44 +74,83 @@ struct LiquidTextConfig {
   }
 }
 
+// MARK: - ViewModel
+
+@available(iOS 26.0, *)
+final class LiquidTextViewModel: ObservableObject {
+  @Published var text: String
+  @Published var fontSize: CGFloat
+  @Published var fontWeight: Font.Weight
+  @Published var textColor: Color?
+  @Published var shape: String
+  @Published var cornerRadius: CGFloat?
+  @Published var tint: Color?
+  @Published var interactive: Bool
+  @Published var padding: EdgeInsets
+
+  init(config: LiquidTextConfig) {
+    self.text = config.text
+    self.fontSize = config.fontSize
+    self.fontWeight = config.fontWeight
+    self.textColor = config.textColor
+    self.shape = config.shape
+    self.cornerRadius = config.cornerRadius
+    self.tint = config.tint
+    self.interactive = config.interactive
+    self.padding = config.padding
+  }
+
+  func apply(_ config: LiquidTextConfig) {
+    text = config.text
+    fontSize = config.fontSize
+    fontWeight = config.fontWeight
+    textColor = config.textColor
+    shape = config.shape
+    cornerRadius = config.cornerRadius
+    tint = config.tint
+    interactive = config.interactive
+    padding = config.padding
+  }
+}
+
 // MARK: - SwiftUI View
 
 @available(iOS 26.0, *)
 struct LiquidTextSwiftUI: View {
-  let config: LiquidTextConfig
+  @ObservedObject var viewModel: LiquidTextViewModel
 
   var body: some View {
     let s = glassShape
     // Only override foreground when a color is explicitly set.
     // Without this, the glass effect applies natural vibrant text treatment.
     styledText
-      .padding(config.padding)
+      .padding(viewModel.padding)
       .glassEffect(glassEffect, in: s)
       .animation(.easeInOut(duration: 0.25), value: animState)
   }
 
   @ViewBuilder
   private var styledText: some View {
-    if let color = config.textColor {
-      Text(config.text)
-        .font(.system(size: config.fontSize, weight: config.fontWeight))
+    if let color = viewModel.textColor {
+      Text(viewModel.text)
+        .font(.system(size: viewModel.fontSize, weight: viewModel.fontWeight))
         .foregroundStyle(color)
     } else {
-      Text(config.text)
-        .font(.system(size: config.fontSize, weight: config.fontWeight))
+      Text(viewModel.text)
+        .font(.system(size: viewModel.fontSize, weight: viewModel.fontWeight))
     }
   }
 
   private var glassEffect: Glass {
     var glass = Glass.regular
-    if let tint = config.tint { glass = glass.tint(tint) }
-    if config.interactive { glass = glass.interactive() }
+    if let tint = viewModel.tint { glass = glass.tint(tint) }
+    if viewModel.interactive { glass = glass.interactive() }
     return glass
   }
 
   private var glassShape: AnyShape {
-    switch config.shape {
-    case "rect":   return AnyShape(RoundedRectangle(cornerRadius: config.cornerRadius ?? 0))
+    switch viewModel.shape {
+    case "rect":   return AnyShape(RoundedRectangle(cornerRadius: viewModel.cornerRadius ?? 0))
     case "circle": return AnyShape(Circle())
     default:       return AnyShape(Capsule())
     }
@@ -131,13 +170,13 @@ struct LiquidTextSwiftUI: View {
 
   private var animState: AnimState {
     AnimState(
-      text: config.text,
-      fontSize: config.fontSize,
-      textColor: config.textColor,
-      tint: config.tint,
-      interactive: config.interactive,
-      shape: config.shape,
-      cornerRadius: config.cornerRadius
+      text: viewModel.text,
+      fontSize: viewModel.fontSize,
+      textColor: viewModel.textColor,
+      tint: viewModel.tint,
+      interactive: viewModel.interactive,
+      shape: viewModel.shape,
+      cornerRadius: viewModel.cornerRadius
     )
   }
 }
@@ -147,8 +186,9 @@ struct LiquidTextSwiftUI: View {
 @available(iOS 26.0, *)
 class LiquidTextPlatformView: NSObject, FlutterPlatformView {
   private let container: UIView
-  private var hostingController: UIHostingController<LiquidTextSwiftUI>
+  private let hostingController: UIHostingController<LiquidTextSwiftUI>
   private let channel: FlutterMethodChannel
+  private let viewModel: LiquidTextViewModel
 
   init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(
@@ -160,7 +200,10 @@ class LiquidTextPlatformView: NSObject, FlutterPlatformView {
     self.container.clipsToBounds = false
 
     let config = LiquidTextConfig.parse(from: args)
-    self.hostingController = UIHostingController(rootView: LiquidTextSwiftUI(config: config))
+    let viewModel = LiquidTextViewModel(config: config)
+    self.viewModel = viewModel
+
+    self.hostingController = UIHostingController(rootView: LiquidTextSwiftUI(viewModel: viewModel))
     self.hostingController.view.backgroundColor = .clear
     self.hostingController.overrideUserInterfaceStyle = config.isDark ? .dark : .light
 
@@ -180,7 +223,7 @@ class LiquidTextPlatformView: NSObject, FlutterPlatformView {
       switch call.method {
       case ChannelConstants.methodUpdateConfig:
         let cfg = LiquidTextConfig.parse(from: call.arguments)
-        self.hostingController.rootView = LiquidTextSwiftUI(config: cfg)
+        self.viewModel.apply(cfg)
         self.hostingController.overrideUserInterfaceStyle = cfg.isDark ? .dark : .light
         result(nil)
       case ChannelConstants.methodSetBrightness:
@@ -195,6 +238,10 @@ class LiquidTextPlatformView: NSObject, FlutterPlatformView {
         result(FlutterMethodNotImplemented)
       }
     }
+  }
+
+  deinit {
+    channel.setMethodCallHandler(nil)
   }
 
   func view() -> UIView { container }

--- a/lib/components/button.dart
+++ b/lib/components/button.dart
@@ -196,6 +196,7 @@ class CNButton extends StatefulWidget {
 }
 
 class _CNButtonState extends State<CNButton> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
   bool? _lastIsDark;
   int? _lastTint;
@@ -373,6 +374,7 @@ class _CNButtonState extends State<CNButton> {
 
     final platformView = buildCupertinoPlatformView(
       context,
+      key: _viewKey,
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: _onCreated,

--- a/lib/components/floating_island.dart
+++ b/lib/components/floating_island.dart
@@ -176,6 +176,7 @@ class CNFloatingIsland extends StatefulWidget {
 
 class _CNFloatingIslandState extends State<CNFloatingIsland>
     with SingleTickerProviderStateMixin {
+  final _viewKey = UniqueKey();
   late AnimationController _animationController;
   late Animation<double> _expandAnimation;
 
@@ -306,6 +307,7 @@ class _CNFloatingIslandState extends State<CNFloatingIsland>
 
     final platformView = buildCupertinoPlatformView(
       context,
+      key: _viewKey,
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: _onPlatformViewCreated,

--- a/lib/components/glass_button_group.dart
+++ b/lib/components/glass_button_group.dart
@@ -105,6 +105,7 @@ class CNGlassButtonGroup extends StatefulWidget {
 }
 
 class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
   List<_ButtonSnapshot>? _lastButtonSnapshots;
   Axis? _lastAxis;
@@ -112,14 +113,36 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
   double? _lastSpacingForGlass;
   bool? _lastIsDark;
 
+  /// Cached future for FutureBuilder – rebuilt only when buttons change.
+  Future<List<Map<String, dynamic>>>? _creationParamsFuture;
+
   /// Whether we're using widget mode (backward compatibility).
   bool get _usingWidgets => widget._buttonWidgets != null;
 
   bool get _isDark => ThemeHelper.isDark(context);
 
+  /// (Re)builds and caches the creation-params future.
+  void _rebuildCreationParamsFuture(BuildContext context) {
+    _creationParamsFuture = _usingWidgets
+        ? Future.wait(
+            widget._buttonWidgets!.map(
+              (button) => _buttonWidgetToMapAsync(button, context),
+            ),
+          )
+        : Future.wait(
+            widget.buttons.map(
+              (button) => _buttonDataToMapAsync(button, context),
+            ),
+          );
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    // Build the future on first mount only (initState has no context).
+    if (_creationParamsFuture == null) {
+      _rebuildCreationParamsFuture(context);
+    }
     _syncBrightnessIfNeeded();
   }
 
@@ -127,6 +150,30 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
   void didUpdateWidget(covariant CNGlassButtonGroup oldWidget) {
     super.didUpdateWidget(oldWidget);
     _syncBrightnessIfNeeded();
+
+    // Invalidate the cached future only when the button list actually changed.
+    final currentSnapshots = _usingWidgets
+        ? widget._buttonWidgets!
+              .map((b) => _ButtonSnapshot.fromButtonWidget(b))
+              .toList()
+        : widget.buttons.map((b) => _ButtonSnapshot.fromButtonData(b)).toList();
+
+    final previousSnapshots = _usingWidgets
+        ? oldWidget._buttonWidgets!
+              .map((b) => _ButtonSnapshot.fromButtonWidget(b))
+              .toList()
+        : oldWidget.buttons
+              .map((b) => _ButtonSnapshot.fromButtonData(b))
+              .toList();
+
+    final buttonsChanged =
+        previousSnapshots.length != currentSnapshots.length ||
+        !_snapshotsEqual(previousSnapshots, currentSnapshots);
+
+    if (buttonsChanged) {
+      _rebuildCreationParamsFuture(context);
+    }
+
     _syncButtonsToNativeIfNeeded();
   }
 
@@ -161,17 +208,7 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
     const viewType = ViewTypes.cupertinoNativeGlassButtonGroup;
 
     return FutureBuilder<List<Map<String, dynamic>>>(
-      future: _usingWidgets
-          ? Future.wait(
-              widget._buttonWidgets!.map(
-                (button) => _buttonWidgetToMapAsync(button, context),
-              ),
-            )
-          : Future.wait(
-              widget.buttons.map(
-                (button) => _buttonDataToMapAsync(button, context),
-              ),
-            ),
+      future: _creationParamsFuture,
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const SizedBox.shrink();
@@ -187,6 +224,7 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup> {
 
         final platformView = buildCupertinoPlatformView(
           context,
+          key: _viewKey,
           viewType: viewType,
           creationParams: creationParams,
           onPlatformViewCreated: _onCreated,

--- a/lib/components/icon.dart
+++ b/lib/components/icon.dart
@@ -63,6 +63,7 @@ class CNIconView extends StatefulWidget {
 }
 
 class _CNIconViewState extends State<CNIconView> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
   bool? _lastIsDark;
   String? _lastName;
@@ -70,7 +71,12 @@ class _CNIconViewState extends State<CNIconView> {
   int? _lastColor;
   String? _lastMode;
   bool? _lastGradient;
-  // No intrinsic sizing storage; icons use explicit size.
+  // Cached futures for FutureBuilder — rebuilt only when source changes.
+  Future<String>? _assetPathFuture;
+  String? _lastAssetPath;
+  Future<Uint8List?>? _customIconFuture;
+  IconData? _lastCustomIcon;
+  double? _lastCustomIconSize;
 
   bool get _isDark => ThemeHelper.isDark(context);
 
@@ -122,8 +128,13 @@ class _CNIconViewState extends State<CNIconView> {
 
     // Handle image asset (highest priority)
     if (widget.imageAsset != null) {
+      final assetPath = widget.imageAsset!.assetPath;
+      if (assetPath != _lastAssetPath) {
+        _lastAssetPath = assetPath;
+        _assetPathFuture = resolveAssetPathForPixelRatio(assetPath);
+      }
       return FutureBuilder<String>(
-        future: resolveAssetPathForPixelRatio(widget.imageAsset!.assetPath),
+        future: _assetPathFuture,
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
             final defaultSize =
@@ -148,8 +159,17 @@ class _CNIconViewState extends State<CNIconView> {
     // Handle custom icon (medium priority)
     if (widget.customIcon != null) {
       final iconSize = widget.size ?? widget.symbol?.size ?? 24.0;
+      if (widget.customIcon != _lastCustomIcon ||
+          iconSize != _lastCustomIconSize) {
+        _lastCustomIcon = widget.customIcon;
+        _lastCustomIconSize = iconSize;
+        _customIconFuture = iconDataToImageBytes(
+          widget.customIcon!,
+          size: iconSize,
+        );
+      }
       return FutureBuilder<Uint8List?>(
-        future: iconDataToImageBytes(widget.customIcon!, size: iconSize),
+        future: _customIconFuture,
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
             return SizedBox(width: iconSize, height: widget.height ?? iconSize);
@@ -232,6 +252,7 @@ class _CNIconViewState extends State<CNIconView> {
 
     final platformView = buildCupertinoPlatformView(
       context,
+      key: _viewKey,
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: _onPlatformViewCreated,

--- a/lib/components/icon.dart
+++ b/lib/components/icon.dart
@@ -7,6 +7,7 @@ import '../style/sf_symbol.dart';
 import '../utils/platform_view_builder.dart';
 import '../utils/icon_renderer.dart';
 import '../utils/theme_helper.dart';
+import '../utils/platform_view_guard.dart';
 import '../utils/version_detector.dart';
 
 /// A platform-rendered SF Symbol icon, custom image asset, or IconData.
@@ -74,6 +75,19 @@ class _CNIconViewState extends State<CNIconView> {
   bool get _isDark => ThemeHelper.isDark(context);
 
   @override
+  void initState() {
+    super.initState();
+    if (!PlatformViewGuard.isReady) {
+      PlatformViewGuard.ensureScheduled();
+      PlatformViewGuard.readyNotifier.addListener(_onPlatformViewGuardReady);
+    }
+  }
+
+  void _onPlatformViewGuardReady() {
+    if (mounted) setState(() {});
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _syncBrightnessIfNeeded();
@@ -87,6 +101,7 @@ class _CNIconViewState extends State<CNIconView> {
 
   @override
   void dispose() {
+    PlatformViewGuard.readyNotifier.removeListener(_onPlatformViewGuardReady);
     _channel?.setMethodCallHandler(null);
     super.dispose();
   }
@@ -98,8 +113,8 @@ class _CNIconViewState extends State<CNIconView> {
     // (regardless of PlatformVersion initialization or iOS version)
     final shouldUseNative = PlatformVersion.supportsSFSymbols;
 
-    // Fallback to Flutter widgets for non-iOS/macOS only
-    if (!shouldUseNative) {
+    // Fallback to Flutter widgets for non-iOS/macOS or while guard is not ready
+    if (!shouldUseNative || !PlatformViewGuard.isReady) {
       return _buildFlutterIcon(context);
     }
 

--- a/lib/components/liquid_glass_container.dart
+++ b/lib/components/liquid_glass_container.dart
@@ -7,6 +7,7 @@ import '../channel/view_types.dart';
 import '../style/glass_effect.dart';
 import '../utils/platform_view_builder.dart';
 import '../utils/theme_helper.dart';
+import '../utils/platform_view_guard.dart';
 import '../utils/version_detector.dart';
 
 /// A container that applies Liquid Glass effects to its child widget.
@@ -46,6 +47,19 @@ class _LiquidGlassContainerState extends State<LiquidGlassContainer> {
   bool get _isDark => ThemeHelper.isDark(context);
 
   @override
+  void initState() {
+    super.initState();
+    if (!PlatformViewGuard.isReady) {
+      PlatformViewGuard.ensureScheduled();
+      PlatformViewGuard.readyNotifier.addListener(_onPlatformViewGuardReady);
+    }
+  }
+
+  void _onPlatformViewGuardReady() {
+    if (mounted) setState(() {});
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _syncBrightnessIfNeeded();
@@ -60,14 +74,24 @@ class _LiquidGlassContainerState extends State<LiquidGlassContainer> {
   }
 
   @override
+  void dispose() {
+    PlatformViewGuard.readyNotifier.removeListener(_onPlatformViewGuardReady);
+    _channel?.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final isIOSOrMacOS =
         defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS;
-    final shouldUseNative = isIOSOrMacOS && PlatformVersion.supportsLiquidGlass;
+    final shouldUseNative =
+        isIOSOrMacOS &&
+        PlatformVersion.supportsLiquidGlass &&
+        PlatformViewGuard.isReady;
 
     if (!shouldUseNative) {
-      // On unsupported platforms or versions, just return the child
+      // On unsupported platforms, versions, or while guard is not ready
       return widget.child;
     }
 

--- a/lib/components/popup_menu_button.dart
+++ b/lib/components/popup_menu_button.dart
@@ -188,6 +188,7 @@ class CNPopupMenuButton extends StatefulWidget {
 }
 
 class _CNPopupMenuButtonState extends State<CNPopupMenuButton> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
   bool? _lastIsDark;
   int? _lastTint;
@@ -531,39 +532,15 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton> {
       if (capturedLabelStyle != null) 'labelStyle': capturedLabelStyle,
     };
 
-    // Create a comprehensive key that includes all parameters affecting platform view creation
-    final buttonIconKey =
-        '${widget.buttonLabel}_${widget.buttonIcon?.name}_${widget.buttonImageAsset?.assetPath}_${widget.buttonImageAsset?.imageData?.length ?? 0}_${widget.buttonCustomIcon?.hashCode ?? 0}';
-    final itemsKey = widget.items
-        .map((e) {
-          if (e is CNPopupMenuItem) {
-            return '${e.label}_${e.icon?.name}_${e.imageAsset?.assetPath}_${e.imageAsset?.imageData?.length ?? 0}_${e.customIcon?.hashCode ?? 0}';
-          }
-          return 'divider';
-        })
-        .join('|');
-    final viewKey = ValueKey(
-      'popupMenu_'
-      '$buttonIconKey|'
-      '$itemsKey|'
-      '${widget.buttonStyle.name}_'
-      '${widget.height}_'
-      '${widget.width}_'
-      '${widget.tint?.toARGB32()}_'
-      '$_isDark',
-    );
-
-    final platformView = KeyedSubtree(
-      key: viewKey,
-      child: buildCupertinoPlatformView(
-        context,
-        viewType: viewType,
-        creationParams: creationParams,
-        onPlatformViewCreated: _onCreated,
-        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
-          Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
-        },
-      ),
+    final platformView = buildCupertinoPlatformView(
+      context,
+      key: _viewKey,
+      viewType: viewType,
+      creationParams: creationParams,
+      onPlatformViewCreated: _onCreated,
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
+        Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
+      },
     );
 
     return LayoutBuilder(

--- a/lib/components/search_bar.dart
+++ b/lib/components/search_bar.dart
@@ -184,6 +184,7 @@ class CNSearchBar extends StatefulWidget {
 
 class _CNSearchBarState extends State<CNSearchBar>
     with SingleTickerProviderStateMixin {
+  final _viewKey = UniqueKey();
   late AnimationController _animationController;
   late Animation<double> _expandAnimation;
   late TextEditingController _textController;
@@ -375,6 +376,7 @@ class _CNSearchBarState extends State<CNSearchBar>
 
     final platformView = buildCupertinoPlatformView(
       context,
+      key: _viewKey,
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: _onPlatformViewCreated,

--- a/lib/components/search_scaffold.dart
+++ b/lib/components/search_scaffold.dart
@@ -126,6 +126,7 @@ class CNSearchScaffold extends StatefulWidget {
 }
 
 class _CNSearchScaffoldState extends State<CNSearchScaffold> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
   int? _lastIndex;
   bool _isSearchActive = false;
@@ -234,6 +235,7 @@ class _CNSearchScaffoldState extends State<CNSearchScaffold> {
         Positioned.fill(
           child: buildCupertinoPlatformView(
             context,
+            key: _viewKey,
             viewType: ViewTypes.cnSearchScaffold,
             creationParams: creationParams,
             onPlatformViewCreated: _onCreated,

--- a/lib/components/segmented_control.dart
+++ b/lib/components/segmented_control.dart
@@ -90,6 +90,7 @@ class CNSegmentedControl extends StatefulWidget {
 }
 
 class _CNSegmentedControlState extends State<CNSegmentedControl> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
 
   int? _lastSelected;
@@ -204,6 +205,7 @@ class _CNSegmentedControlState extends State<CNSegmentedControl> {
 
     final platformView = buildCupertinoPlatformView(
       context,
+      key: _viewKey,
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: _onPlatformViewCreated,

--- a/lib/components/slider.dart
+++ b/lib/components/slider.dart
@@ -110,6 +110,7 @@ class CNSlider extends StatefulWidget {
 }
 
 class _CNSliderState extends State<CNSlider> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
 
   double? _lastValue;
@@ -216,6 +217,7 @@ class _CNSliderState extends State<CNSlider> {
 
     final platformView = buildCupertinoPlatformView(
       context,
+      key: _viewKey,
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: _onPlatformViewCreated,

--- a/lib/components/switch.dart
+++ b/lib/components/switch.dart
@@ -80,6 +80,7 @@ class CNSwitch extends StatefulWidget {
 }
 
 class _CNSwitchState extends State<CNSwitch> {
+  final _viewKey = UniqueKey();
   MethodChannel? _channel;
 
   bool? _lastValue;
@@ -170,6 +171,7 @@ class _CNSwitchState extends State<CNSwitch> {
 
     final platformView = buildCupertinoPlatformView(
       context,
+      key: _viewKey,
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: _onPlatformViewCreated,

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -645,6 +645,9 @@ class _CNTabBarState extends State<CNTabBar> {
         final leftCount = widget.items.length - widget.rightCount;
         final isRightButton =
             widget.split && widget.splitRightAsButton && idx >= leftCount;
+        debugPrint(
+          '[CNTabBar Dart] valueChanged idx:$idx lastIndex:$_lastIndex isRightButton:$isRightButton currentIndex:${widget.currentIndex}',
+        );
         if (isRightButton) {
           // Button mode: always fire callback, don't update _lastIndex
           widget.onTap(idx);
@@ -684,6 +687,9 @@ class _CNTabBarState extends State<CNTabBar> {
 
     try {
       if (_lastIndex != idx) {
+        debugPrint(
+          '[CNTabBar Dart] _syncProps calling setSelectedIndex idx:$idx (was _lastIndex:$_lastIndex)',
+        );
         await ch.invokeMethod('setSelectedIndex', {'index': idx});
         _lastIndex = idx;
       }

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -9,6 +9,7 @@ import '../style/sf_symbol.dart';
 import '../utils/platform_view_builder.dart';
 import '../style/tab_bar_search_item.dart';
 import '../utils/icon_renderer.dart';
+import '../utils/platform_view_guard.dart';
 import '../utils/version_detector.dart';
 import '../utils/theme_helper.dart';
 import 'icon.dart';
@@ -110,6 +111,7 @@ class CNTabBar extends StatefulWidget {
     this.shrinkCentered = true,
     this.splitSpacing =
         12.0, // Apple's recommended spacing for visual separation
+    this.splitRightAsButton = false,
     this.searchItem,
     this.searchController,
     this.labelStyle,
@@ -172,6 +174,12 @@ class CNTabBar extends StatefulWidget {
   /// Defaults to 12pt following Apple's HIG recommendations for visual separation.
   final double splitSpacing; // gap between left/right halves when split
 
+  /// When true and [split] is enabled, the right-side items act as plain
+  /// buttons instead of selectable tabs. Tapping them fires [onTap] but
+  /// does not change the visual selection — selection is controlled solely
+  /// by [currentIndex].
+  final bool splitRightAsButton;
+
   /// Optional search tab configuration.
   ///
   /// When provided, adds a dedicated search tab that follows iOS 26's native
@@ -225,6 +233,7 @@ class _CNTabBarState extends State<CNTabBar> {
   bool? _lastSplit;
   int? _lastRightCount;
   double? _lastSplitSpacing;
+  bool? _lastSplitRightAsButton;
   Map<String, dynamic>? _lastLabelStyle;
   Map<String, dynamic>? _lastActiveLabelStyle;
 
@@ -252,7 +261,15 @@ class _CNTabBarState extends State<CNTabBar> {
     if (_hasSearch) {
       _searchFocusNode = FocusNode();
     }
+    if (!PlatformViewGuard.isReady) {
+      PlatformViewGuard.ensureScheduled();
+      PlatformViewGuard.readyNotifier.addListener(_onPlatformViewGuardReady);
+    }
     _nativeTabBarFuture = _createNativeTabBarFuture();
+  }
+
+  void _onPlatformViewGuardReady() {
+    if (mounted) setState(() {});
   }
 
   @override
@@ -301,6 +318,7 @@ class _CNTabBarState extends State<CNTabBar> {
   void dispose() {
     widget.searchController?.removeListener(_onSearchControllerChanged);
     _searchFocusNode?.dispose();
+    PlatformViewGuard.readyNotifier.removeListener(_onPlatformViewGuardReady);
     _channel?.setMethodCallHandler(null);
     super.dispose();
   }
@@ -339,11 +357,12 @@ class _CNTabBarState extends State<CNTabBar> {
         defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS;
     final shouldUseNative =
-        isIOSOrMacOS && PlatformVersion.shouldUseNativeGlass;
+        isIOSOrMacOS &&
+        PlatformVersion.shouldUseNativeGlass &&
+        PlatformViewGuard.isReady;
 
-    // Fallback to Flutter widgets for non-iOS/macOS or iOS/macOS < 26
+    // Fallback to Flutter widgets for non-iOS/macOS, iOS/macOS < 26, or while guard is not ready
     if (!shouldUseNative) {
-      // For both non-iOS/macOS and iOS/macOS < 26, use Flutter-based implementation
       return _buildFlutterFallback(context);
     }
 
@@ -477,6 +496,7 @@ class _CNTabBarState extends State<CNTabBar> {
       'split': _hasSearch ? true : widget.split,
       'rightCount': widget.rightCount,
       'splitSpacing': widget.splitSpacing,
+      'splitRightAsButton': widget.splitRightAsButton,
       'style': capturedStyle
         ..addAll({
           if (capturedBackgroundColor != null)
@@ -593,6 +613,7 @@ class _CNTabBarState extends State<CNTabBar> {
     _lastSplit = widget.split;
     _lastRightCount = widget.rightCount;
     _lastSplitSpacing = widget.splitSpacing;
+    _lastSplitRightAsButton = widget.splitRightAsButton;
     _lastLabelStyle = encodeTextStyle(widget.labelStyle, context);
     _lastActiveLabelStyle = encodeTextStyle(widget.activeLabelStyle, context);
 
@@ -620,9 +641,17 @@ class _CNTabBarState extends State<CNTabBar> {
     if (call.method == 'valueChanged') {
       final args = call.arguments as Map?;
       final idx = (args?['index'] as num?)?.toInt();
-      if (idx != null && idx != _lastIndex) {
-        widget.onTap(idx);
-        _lastIndex = idx;
+      if (idx != null) {
+        final leftCount = widget.items.length - widget.rightCount;
+        final isRightButton =
+            widget.split && widget.splitRightAsButton && idx >= leftCount;
+        if (isRightButton) {
+          // Button mode: always fire callback, don't update _lastIndex
+          widget.onTap(idx);
+        } else if (idx != _lastIndex) {
+          widget.onTap(idx);
+          _lastIndex = idx;
+        }
       }
     } else if (call.method == 'searchTextChanged') {
       final args = call.arguments as Map?;
@@ -809,7 +838,7 @@ class _CNTabBarState extends State<CNTabBar> {
         _requestIntrinsicSize();
       }
 
-      // Layout updates (split / insets)
+      // Structural layout updates (require tab bar recreation)
       if (_lastSplit != widget.split ||
           _lastRightCount != widget.rightCount ||
           _lastSplitSpacing != widget.splitSpacing) {
@@ -818,11 +847,35 @@ class _CNTabBarState extends State<CNTabBar> {
           'rightCount': widget.rightCount,
           'splitSpacing': widget.splitSpacing,
           'selectedIndex': widget.currentIndex,
+          'splitRightAsButton': widget.splitRightAsButton,
         });
         _lastSplit = widget.split;
         _lastRightCount = widget.rightCount;
         _lastSplitSpacing = widget.splitSpacing;
+        _lastSplitRightAsButton = widget.splitRightAsButton;
         _requestIntrinsicSize();
+        // setLayout recreates the tab bars — trigger refresh to force label
+        // rendering (same cycle-through-items trick used after initial creation).
+        if (defaultTargetPlatform == TargetPlatform.iOS) {
+          Future.delayed(const Duration(milliseconds: 50), () async {
+            if (mounted && _channel != null) {
+              try {
+                await _channel?.invokeMethod('refresh');
+                await _channel?.invokeMethod('setSelectedIndex', {
+                  'index': widget.currentIndex,
+                });
+              } catch (_) {}
+            }
+          });
+        }
+      }
+
+      // Behavioral update only — no tab bar recreation needed
+      if (_lastSplitRightAsButton != widget.splitRightAsButton) {
+        await ch.invokeMethod('setSplitRightAsButton', {
+          'value': widget.splitRightAsButton,
+        });
+        _lastSplitRightAsButton = widget.splitRightAsButton;
       }
 
       // Label style sync

--- a/lib/cupertino_native.dart
+++ b/lib/cupertino_native.dart
@@ -36,6 +36,7 @@ export 'style/tab_bar_search_item.dart';
 // Utilities
 export 'utils/version_detector.dart';
 export 'utils/theme_helper.dart';
+export 'utils/platform_view_guard.dart';
 
 import 'cupertino_native_platform_interface.dart';
 

--- a/lib/utils/platform_view_guard.dart
+++ b/lib/utils/platform_view_guard.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/widgets.dart';
+
+/// Guards platform-view creation during app startup / hot-restart.
+///
+/// On iOS, `FlutterPlatformViewsController` may retain residual view
+/// registrations from a previous Dart isolate immediately after a hot
+/// restart. If the new isolate's widgets request platform-view creation
+/// before the engine has fully purged these stale registrations, it
+/// rejects them with `PlatformException(recreating_view, ...)`.
+///
+/// This guard delays platform-view widgets by a short fixed duration
+/// (500 ms) after the first widget requests readiness, giving the
+/// engine ample time to run its internal cleanup.  The delay fires
+/// only once per app lifetime — subsequent checks are instantaneous.
+///
+/// Usage inside component `build` methods:
+/// ```dart
+/// if (!PlatformViewGuard.isReady) {
+///   PlatformViewGuard.ensureScheduled();
+///   return _fallbackWidget();
+/// }
+/// return UiKitView(...);
+/// ```
+class PlatformViewGuard {
+  PlatformViewGuard._();
+
+  static bool _ready = false;
+  static bool _scheduled = false;
+
+  /// Whether it is safe to create platform views.
+  static bool get isReady => _ready;
+
+  /// Notifier that fires once when readiness flips to `true`.
+  static final ValueNotifier<bool> readyNotifier = ValueNotifier<bool>(false);
+
+  /// Schedules the readiness flip if it hasn't been scheduled yet.
+  ///
+  /// A 500 ms timer is used instead of post-frame callbacks because
+  /// the engine's platform-view cleanup runs asynchronously and may
+  /// not complete within one or two vsync intervals.  500 ms is long
+  /// enough for the engine to finish while remaining imperceptible
+  /// to the user (the Flutter fallback widgets are shown meanwhile).
+  static void ensureScheduled() {
+    if (_ready || _scheduled) return;
+    _scheduled = true;
+
+    Future<void>.delayed(const Duration(milliseconds: 500), () {
+      if (_ready) return;
+      _ready = true;
+      readyNotifier.value = true;
+    });
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cupertino_native_plus
 description: Native Liquid Glass widgets for iOS and macOS with pixel-perfect fidelity.
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/NarekManukyan/cupertino_native_plus
 issue_tracker: https://github.com/NarekManukyan/cupertino_native_plus/issues
 


### PR DESCRIPTION
- Added `deinit` methods to all platform views to ensure proper cleanup of method channel handlers and view hierarchy on deallocation.
- Implemented `UniqueKey` for various components to prevent unnecessary destruction and recreation of native views during parent rebuilds.
- Introduced caching for async creation futures in `CNGlassButtonGroup` and `CNIconView` to reduce flicker on rebuilds.
- Updated `LiquidGlassContainer` and `LiquidText` to utilize `@ObservedObject` for better state management and performance optimization.
- Improved `splitRightAsButton` handling to minimize layout rebuilds, enhancing responsiveness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.0.8

* **New Features**
  * Added `splitRightAsButton` option to tab bar that converts right-side items into action buttons (tap triggers callback without changing selection)
  * Improved iOS startup stability with automatic platform-view initialization delay to prevent hot-restart crashes

* **Bug Fixes**
  * Fixed tab selection state restoration in split and standard tab-bar modes

* **Performance**
  * Enhanced native-view stability and reduced visual flickering
  * Improved platform-view lifecycle management for consistent behavior across rebuilds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->