### PR TITLE
chore: exclude example build artifacts from .pubignore

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -3,6 +3,14 @@ example/build/
 example/.dart_tool/
 .dart_tool/
 
+# Example app native dependency artifacts (CocoaPods, Flutter-generated, symlinks)
+example/.flutter-plugins-dependencies
+example/ios/.symlinks/
+example/ios/Flutter/
+example/ios/Pods/
+example/macos/Flutter/ephemeral/
+example/macos/Pods/
+
 # IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary

- Adds `example/ios/{Pods,.symlinks,Flutter}/`, `example/macos/Flutter/ephemeral/`, and `example/.flutter-plugins-dependencies` to `.pubignore`.
- These were appearing in the published archive because they're checked in despite being `.gitignore`d (Pub publishes tracked files unless `.pubignore` excludes them).
- Hand-verified via `flutter pub publish --dry-run` that the archive tree no longer contains `Pods/`, `.symlinks/`, or `Flutter/{Generated.xcconfig,ephemeral/,flutter_export_environment.sh}`.
- Intentional source files (`Flutter-Debug.xcconfig`, `Flutter-Release.xcconfig`, `AppFrameworkInfo.plist`, `Flutter.podspec`) remain.

Note: The dry-run still prints the 1-warning "files gitignored but checked in" message because that check is informational about tracking state, not about archive contents. Fully suppressing requires `git rm --cached -r` of the files — out of scope here.

## Test plan

- [x] `flutter pub publish --dry-run` — archive no longer contains Pods/symlinks/ephemeral
- [ ] Verify with next release publish