### PR TITLE
Native Tab Bar: Scroll Shrink, Lifecycle Fixes & Transition Polish

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(flutter pub *)",
+      "Bash(flutter build *)",
+      "Bash(flutter clean *)"
+    ]
+  }
+}

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -22,6 +22,9 @@ class CNNativeTabBarManager: NSObject {
     private var shrinkOffset: CGFloat = 16
     private var lastScrollOffset: CGFloat = 0
     private var isTabBarShrunk: Bool = false
+    /// Raw string from Flutter, mapped to `UITabBarController.MinimizeBehavior`
+    /// when applied: "never" | "onScrollDown" | "onScrollUp" | "automatic".
+    private var minimizeBehaviorRaw: String = "automatic"
 
     struct TabConfig {
         let title: String
@@ -319,18 +322,28 @@ class CNNativeTabBarManager: NSObject {
             return
         }
 
-        // Remove Flutter view from search-only nav controller if present
-        if let navController = searchOnlyNavController,
-            let searchVC = navController.topViewController as? FlutterTabViewController
-        {
-            searchVC.removeFlutterView()
+        // Fully detach FlutterViewController from whichever FlutterTabViewController
+        // is currently hosting it. removeFlutterView() only removes the view; without
+        // the full VC-containment teardown UIKit throws the "wrong parent" assertion
+        // when flutterVC is later set as the window's rootViewController.
+        func detach(from vc: UIViewController) {
+            if let tabVC = vc as? FlutterTabViewController {
+                tabVC.removeFlutter(flutterVC)
+            } else if let nav = vc as? UINavigationController,
+                let tabVC = nav.topViewController as? FlutterTabViewController
+            {
+                tabVC.removeFlutter(flutterVC)
+            }
         }
 
-        // Remove Flutter view from tab if embedded
-        if let tabBar = tabBarController,
-            let selectedVC = tabBar.selectedViewController as? FlutterTabViewController
-        {
-            selectedVC.removeFlutterView()
+        if let navController = searchOnlyNavController {
+            detach(from: navController)
+        }
+
+        if let tabBar = tabBarController {
+            for vc in tabBar.viewControllers ?? [] {
+                detach(from: vc)
+            }
         }
 
         // Restore Flutter as root
@@ -357,6 +370,90 @@ class CNNativeTabBarManager: NSObject {
         tabBar.tabBar.backgroundImage = UIImage()
         tabBar.tabBar.shadowImage = UIImage()
         tabBar.tabBar.backgroundColor = .clear
+
+        // Leading/trailing inset from the window edges. `UITabBarAppearance`
+        // has no horizontal-margin property — `UIBarAppearance` only exposes
+        // colors/images/effects — so this is the documented knob: it gives
+        // the tab bar's content area a constant gutter from the screen edges.
+        tabBar.tabBar.insetsLayoutMarginsFromSafeArea = true
+        tabBar.tabBar.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 0, leading: 24, bottom: 0, trailing: 24)
+
+        // iOS 26 native tab-bar minimize behavior — Apple's first-party
+        // collapse-on-scroll handling. Equivalent to SwiftUI's
+        // `TabView.tabBarMinimizeBehavior(_:)`.
+        applyMinimizeBehavior(to: tabBar)
+    }
+
+    /// Maps the raw string from Flutter to `UITabBarController.MinimizeBehavior`
+    /// and applies it. iOS 26+ only; no-op on older systems.
+    private func applyMinimizeBehavior(to tabBar: UITabBarController) {
+        if #available(iOS 26.0, *) {
+            let behavior: UITabBarController.MinimizeBehavior
+            switch minimizeBehaviorRaw {
+            case "never": behavior = .never
+            case "onScrollUp": behavior = .onScrollUp
+            case "onScrollDown": behavior = .onScrollDown
+            case "automatic": behavior = .automatic
+            default: behavior = .automatic
+            }
+            tabBar.tabBarMinimizeBehavior = behavior
+        }
+    }
+
+    /// Composes an SF Symbol inside a tinted circle and returns the result as a
+    /// tab bar item image. Used to give icons a compact, circular silhouette
+    /// when the bar is shrunk.
+    private func circularizedIcon(
+        symbolName: String,
+        tint: UIColor,
+        background: UIColor,
+        diameter: CGFloat = 30
+    ) -> UIImage? {
+        let size = CGSize(width: diameter, height: diameter)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { _ in
+            background.setFill()
+            UIBezierPath(ovalIn: CGRect(origin: .zero, size: size)).fill()
+            let config = UIImage.SymbolConfiguration(
+                pointSize: diameter * 0.55, weight: .semibold)
+            if let symbol = UIImage(systemName: symbolName, withConfiguration: config)?
+                .withTintColor(tint, renderingMode: .alwaysOriginal)
+            {
+                let symbolSize = symbol.size
+                let origin = CGPoint(
+                    x: (size.width - symbolSize.width) / 2,
+                    y: (size.height - symbolSize.height) / 2
+                )
+                symbol.draw(at: origin)
+            }
+        }
+        return image.withRenderingMode(.alwaysOriginal)
+    }
+
+    /// Rebuilds the regular (non-circular) image + selectedImage for a tab
+    /// using the original SF Symbol names and the configured tint colors.
+    private func originalIcons(for config: TabConfig) -> (UIImage?, UIImage?) {
+        var image: UIImage?
+        var selectedImage: UIImage?
+
+        if let symbol = config.sfSymbol, !symbol.isEmpty {
+            if let unselTint = unselectedTintColor {
+                image = UIImage(systemName: symbol)?.withTintColor(
+                    unselTint, renderingMode: .alwaysOriginal)
+            } else {
+                image = UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
+            }
+        }
+
+        if let activeSymbol = config.activeSfSymbol, !activeSymbol.isEmpty {
+            selectedImage = UIImage(systemName: activeSymbol)?
+                .withRenderingMode(.alwaysTemplate)
+        } else {
+            selectedImage = image
+        }
+
+        return (image, selectedImage)
     }
 
     private func showTabBarAnimated() {
@@ -368,6 +465,14 @@ class CNNativeTabBarManager: NSObject {
 
     private func handleScrollOffset(_ offset: CGFloat) {
         guard let tabBar = tabBarController else { return }
+        // `"never"` mirrors UITabBarController.MinimizeBehavior.never — no shrink at all.
+        guard minimizeBehaviorRaw != "never" else {
+            if isTabBarShrunk {
+                isTabBarShrunk = false
+                applyShrinkState(false, on: tabBar)
+            }
+            return
+        }
 
         if offset <= 0 {
             if isTabBarShrunk {
@@ -382,10 +487,23 @@ class CNNativeTabBarManager: NSObject {
         guard abs(delta) > 4 else { return }
         lastScrollOffset = offset
 
-        if delta > 0 && !isTabBarShrunk {
+        // Map the behavior to the scroll direction that should *shrink* the bar.
+        // `automatic` defaults to `onScrollDown`, which matches the SwiftUI
+        // `TabView.tabBarMinimizeBehavior` default Apple ships for iOS 26.
+        let shrinkOnScrollDown: Bool
+        switch minimizeBehaviorRaw {
+        case "onScrollUp": shrinkOnScrollDown = false
+        case "onScrollDown", "automatic": shrinkOnScrollDown = true
+        default: shrinkOnScrollDown = true
+        }
+
+        let isScrollingDown = delta > 0
+        let shouldShrink = isScrollingDown == shrinkOnScrollDown
+
+        if shouldShrink && !isTabBarShrunk {
             isTabBarShrunk = true
             applyShrinkState(true, on: tabBar)
-        } else if delta < 0 && isTabBarShrunk {
+        } else if !shouldShrink && isTabBarShrunk {
             isTabBarShrunk = false
             applyShrinkState(false, on: tabBar)
         }
@@ -408,20 +526,67 @@ class CNNativeTabBarManager: NSObject {
 
         if let items = tabBar.tabBar.items {
             for (index, item) in items.enumerated() {
+                guard index < tabConfigurations.count else { continue }
+                let config = tabConfigurations[index]
                 if shrunk {
+                    // Drop the label and swap to a circular icon for a compact pill look.
                     item.title = nil
-                } else if index < tabConfigurations.count {
-                    item.title = tabConfigurations[index].title
+                    let tint = tintColor ?? .label
+                    let background = (tintColor ?? UIColor.systemBlue).withAlphaComponent(0.18)
+                    if let symbol = config.sfSymbol, !symbol.isEmpty {
+                        let circular = circularizedIcon(
+                            symbolName: symbol, tint: tint, background: background)
+                        item.image = circular
+                        item.selectedImage = circular
+                    }
+                } else {
+                    item.title = config.title
+                    let (image, selectedImage) = originalIcons(for: config)
+                    item.image = image
+                    item.selectedImage = selectedImage
                 }
             }
         }
 
-        UIView.animate(withDuration: duration) {
+        // Swap the bar's appearance and per-item layout *without* UIKit's
+        // implicit springy transition — wrapping the property changes in a
+        // CATransaction with actions disabled suppresses the bounce iOS 26
+        // adds when these properties change on a visible UITabBar.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        let appearance = UITabBarAppearance()
+        if shrunk {
+            appearance.configureWithTransparentBackground()
+            appearance.backgroundColor = .clear
+            appearance.shadowColor = .clear
+        } else {
+            appearance.configureWithDefaultBackground()
+        }
+        tabBar.tabBar.standardAppearance = appearance
+        if #available(iOS 15.0, *) {
+            tabBar.tabBar.scrollEdgeAppearance = appearance
+        }
+
+        if shrunk {
+            tabBar.tabBar.itemPositioning = .centered
+            tabBar.tabBar.itemWidth = 44
+            tabBar.tabBar.itemSpacing = 24
+        } else {
+            tabBar.tabBar.itemPositioning = .automatic
+            tabBar.tabBar.itemWidth = 0
+            tabBar.tabBar.itemSpacing = 0
+        }
+
+        CATransaction.commit()
+
+        // Smooth, non-bouncing transform: explicit ease-in-out, no spring.
+        UIView.animate(
+            withDuration: duration,
+            delay: 0,
+            options: [.curveEaseInOut, .beginFromCurrentState, .allowUserInteraction]
+        ) {
             if shrunk {
-                // Convert a fixed point-based side margin into a scale factor so
-                // the shrunken bar pulls in by the same number of points on
-                // every screen size, rather than a fixed percentage that looks
-                // tiny on small phones and huge on larger ones.
                 let sideMargin: CGFloat = 24
                 let bottomInset: CGFloat = 8
                 let barWidth = max(tabBar.tabBar.bounds.width, 1)
@@ -483,6 +648,7 @@ class CNNativeTabBarManager: NSObject {
             let isDark = (args["isDark"] as? Bool) ?? false
             let shrink = (args["shrinkWhileScroll"] as? Bool) ?? false
             self.shrinkOffset = CGFloat((args["shrinkOffset"] as? Double) ?? 16)
+            self.minimizeBehaviorRaw = (args["minimizeBehavior"] as? String) ?? "automatic"
 
             // Parse colors
             if let tint = args["tint"] as? Int {
@@ -533,6 +699,17 @@ class CNNativeTabBarManager: NSObject {
         case "isEnabled":
             result(isEnabled)
 
+        case "setMinimizeBehavior":
+            if let args = call.arguments as? [String: Any],
+                let raw = args["minimizeBehavior"] as? String
+            {
+                self.minimizeBehaviorRaw = raw
+                if let tabBar = tabBarController {
+                    applyMinimizeBehavior(to: tabBar)
+                }
+            }
+            result(nil)
+
         case "setBadgeCounts":
             guard let args = call.arguments as? [String: Any],
                 let badgeCounts = args["badgeCounts"] as? [Int?]
@@ -582,9 +759,12 @@ class CNNativeTabBarManager: NSObject {
             result(nil)
 
         case "updateScrollOffset":
+            // Drive the manual shrink workaround whenever Flutter reports scroll.
+            // The minimize behavior is consulted inside `handleScrollOffset` —
+            // `"never"` is a no-op, the rest pick the direction that shrinks.
             if let args = call.arguments as? [String: Any],
                 let offset = args["offset"] as? Double,
-                shrinkWhileScroll
+                shrinkWhileScroll || minimizeBehaviorRaw != "never"
             {
                 handleScrollOffset(CGFloat(offset))
             }
@@ -745,6 +925,23 @@ private class FlutterTabViewController: UIViewController {
 
     func removeFlutterView() {
         embeddedFlutterView?.removeFromSuperview()
+        embeddedFlutterView = nil
+    }
+
+    /// Fully detaches a `FlutterViewController` from this parent, including
+    /// the view-controller containment hierarchy. Call this before making
+    /// `FlutterViewController` the window root; without it UIKit throws
+    /// "child VC should have parent (null) but actual parent is FlutterTabViewController".
+    func removeFlutter(_ flutterVC: FlutterViewController) {
+        guard flutterVC.parent === self else {
+            removeFlutterView()
+            return
+        }
+        flutterVC.willMove(toParent: nil)
+        flutterVC.beginAppearanceTransition(false, animated: false)
+        flutterVC.view.removeFromSuperview()
+        flutterVC.endAppearanceTransition()
+        flutterVC.removeFromParent()
         embeddedFlutterView = nil
     }
 }

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -180,8 +180,6 @@ class CNNativeTabBarManager: NSObject {
         }
 
         tabBar.viewControllers = viewControllers
-        tabBar.selectedIndex = selectedIndex
-        tabBar.delegate = self
 
         // Apply tint colors
         if let tint = tintColor {
@@ -194,7 +192,19 @@ class CNNativeTabBarManager: NSObject {
         // Replace root view controller
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-            // Embed Flutter view in the selected tab
+            // Snapshot Flutter's last rendered frame before we move it
+            let snapshot = flutterVC.view.snapshotView(afterScreenUpdates: false)
+
+            // Set root FIRST so the view hierarchy has proper bounds before embedding Flutter.
+            // selectedIndex and delegate must be set after entering the window — UITabBarController
+            // can silently reset selectedIndex to 0 if set before the controller is in a window.
+            window.rootViewController = tabBar
+            tabBar.selectedIndex = selectedIndex
+            tabBar.delegate = self
+            tabBar.view.setNeedsLayout()
+            tabBar.view.layoutIfNeeded()
+
+            // Embed Flutter now that layout bounds are resolved
             let selectedVC = viewControllers[selectedIndex]
             if let navController = selectedVC as? UINavigationController,
                let rootVC = navController.topViewController as? FlutterTabViewController {
@@ -203,8 +213,16 @@ class CNNativeTabBarManager: NSObject {
                 flutterTabVC.embedFlutterView(flutterVC.view)
             }
 
-            UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
-                window.rootViewController = tabBar
+            // Overlay snapshot to cover the brief gap before Flutter renders its first frame
+            if let snapshot = snapshot {
+                snapshot.frame = window.bounds
+                snapshot.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                window.addSubview(snapshot)
+                UIView.animate(withDuration: 0.3, delay: 0.25, options: .curveEaseInOut) {
+                    snapshot.alpha = 0
+                } completion: { _ in
+                    snapshot.removeFromSuperview()
+                }
             }
 
             self.isEnabled = true
@@ -451,8 +469,25 @@ class CNNativeTabBarManager: NSObject {
 
 extension CNNativeTabBarManager: UITabBarControllerDelegate {
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        let index = tabBarController.viewControllers?.firstIndex(of: viewController) ?? 0
-        notifyTabSelected(index)
+        let index = tabBarController.selectedIndex
+        methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
+
+        guard let flutterView = flutterViewController?.view else { return }
+
+        // Defer view-hierarchy changes so UIKit can finish its own tab transition first.
+        // Moving Flutter's view synchronously inside didSelect interrupts the transition
+        // animation and causes the tab bar to require a second tap before responding.
+        DispatchQueue.main.async { [weak self, weak tabBarController] in
+            guard self != nil, let tabBar = tabBarController else { return }
+            var target: FlutterTabViewController?
+            if let nav = tabBar.selectedViewController as? UINavigationController,
+               let root = nav.topViewController as? FlutterTabViewController {
+                target = root
+            } else if let vc = tabBar.selectedViewController as? FlutterTabViewController {
+                target = vc
+            }
+            target?.embedFlutterView(flutterView)
+        }
     }
 }
 
@@ -499,7 +534,7 @@ private class FlutterTabViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = .clear
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -94,6 +94,7 @@ class CNNativeTabBarManager: NSObject {
         if tabBarController == nil {
             let tabBar = UITabBarController()
             tabBarController = tabBar
+            NSLog("✅ tabBar: \(tabBar.tabBar)")
 
             // Setup iOS 26 appearance
             setupTabBarAppearance(tabBar)
@@ -217,6 +218,13 @@ class CNNativeTabBarManager: NSObject {
             } else if let flutterTabVC = selectedVC as? FlutterTabViewController {
                 flutterTabVC.embedFlutter(flutterVC)
             }
+
+            // UITabBarController does not invoke the delegate's didSelect on the
+            // initial programmatic selection, so Flutter never learns which tab
+            // is active and any state gated on onTabSelected (segment switch,
+            // routing, etc.) stays frozen until the user taps. Fire it manually.
+            methodChannel?.invokeMethod(
+                "onTabSelected", arguments: ["index": selectedIndex])
 
             // Overlay snapshot to cover the brief gap before Flutter renders its first frame
             if let snapshot = snapshot {
@@ -570,6 +578,7 @@ private class FlutterTabViewController: UIViewController {
     }
 
     func embedFlutterView(_ flutterView: UIView) {
+
         // Remove any existing embedded view
         embeddedFlutterView?.removeFromSuperview()
 
@@ -594,7 +603,6 @@ private class FlutterTabViewController: UIViewController {
         ])
 
         embeddedFlutterView = flutterView
-
         // Force layout update
         view.setNeedsLayout()
         view.layoutIfNeeded()
@@ -609,16 +617,26 @@ private class FlutterTabViewController: UIViewController {
     /// orphaned, which is why the engine sticks on its last frame (the splash)
     /// until something else forces a re-layout (e.g. a tab tap).
     func embedFlutter(_ flutterVC: FlutterViewController) {
-        // Detach from any previous parent.
+        // Detach from any previous parent, bracketing with appearance
+        // callbacks so the engine sees a clean disappear before re-attach.
         if let oldParent = flutterVC.parent, oldParent !== self {
             flutterVC.willMove(toParent: nil)
+            flutterVC.beginAppearanceTransition(false, animated: false)
             flutterVC.view.removeFromSuperview()
+            flutterVC.endAppearanceTransition()
             flutterVC.removeFromParent()
         }
 
         if flutterVC.parent !== self {
             addChild(flutterVC)
+            // Manually trigger the appearance transition. Auto-forwarding only
+            // happens during the parent's own appearance cycle; when we add a
+            // child after the parent is already on-screen, viewWillAppear and
+            // viewDidAppear are never delivered, and the Flutter engine waits
+            // for them before resuming rendering.
+            flutterVC.beginAppearanceTransition(true, animated: false)
             embedFlutterView(flutterVC.view)
+            flutterVC.endAppearanceTransition()
             flutterVC.didMove(toParent: self)
         } else {
             embedFlutterView(flutterVC.view)

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -79,7 +79,8 @@ class CNNativeTabBarManager: NSObject {
 
     /// Enable native tab bar mode
     private func enableNativeTabBar(
-        tabs: [TabConfig], selectedIndex: Int, isDark: Bool, shrinkWhileScroll: Bool = false
+        tabs: [TabConfig], selectedIndex: Int, isDark: Bool, shrinkWhileScroll: Bool = false,
+        badgeCounts: [Int?]? = nil
     ) {
         self.shrinkWhileScroll = shrinkWhileScroll
         self.lastScrollOffset = 0
@@ -106,7 +107,6 @@ class CNNativeTabBarManager: NSObject {
         if tabBarController == nil {
             let tabBar = UITabBarController()
             tabBarController = tabBar
-            NSLog("✅ tabBar: \(tabBar.tabBar)")
 
             // Setup iOS 26 appearance
             setupTabBarAppearance(tabBar)
@@ -192,6 +192,18 @@ class CNNativeTabBarManager: NSObject {
                 }
 
                 viewControllers.append(tabVC)
+            }
+        }
+
+        // Top-level badgeCounts takes precedence over per-tab CNTab.badgeCount.
+        if let counts = badgeCounts {
+            for (index, vc) in viewControllers.enumerated() where index < counts.count {
+                let count = counts[index]
+                if let count = count, count > 0 {
+                    vc.tabBarItem.badgeValue = count > 99 ? "99+" : String(count)
+                } else {
+                    vc.tabBarItem.badgeValue = nil
+                }
             }
         }
 
@@ -518,10 +530,11 @@ class CNNativeTabBarManager: NSObject {
     ) {
         // Anchor scaling to the bottom-center so the bar shrinks "into" the
         // home-indicator area rather than drifting up from the screen edge.
+        // position must be in the parent layer's coordinate space — use frame, not bounds.
         tabBar.tabBar.layer.anchorPoint = CGPoint(x: 0.5, y: 1.0)
         tabBar.tabBar.layer.position = CGPoint(
-            x: tabBar.tabBar.bounds.midX,
-            y: tabBar.tabBar.bounds.maxY
+            x: tabBar.tabBar.frame.midX,
+            y: tabBar.tabBar.frame.maxY
         )
 
         if let items = tabBar.tabBar.items {
@@ -587,8 +600,8 @@ class CNNativeTabBarManager: NSObject {
             options: [.curveEaseInOut, .beginFromCurrentState, .allowUserInteraction]
         ) {
             if shrunk {
-                let sideMargin: CGFloat = 24
-                let bottomInset: CGFloat = 8
+                let sideMargin: CGFloat = self.shrinkOffset
+                let bottomInset: CGFloat = self.shrinkOffset / 3
                 let barWidth = max(tabBar.tabBar.bounds.width, 1)
                 let scale = max(0.5, (barWidth - 2 * sideMargin) / barWidth)
                 tabBar.tabBar.transform = CGAffineTransform(translationX: 0, y: -bottomInset)
@@ -603,7 +616,7 @@ class CNNativeTabBarManager: NSObject {
         showTabBarAnimated()
         methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
 
-        guard let flutterView = flutterViewController?.view,
+        guard let flutterVC = flutterViewController,
             let tabBar = tabBarController
         else { return }
 
@@ -618,7 +631,7 @@ class CNNativeTabBarManager: NSObject {
         }
 
         if let vc = targetVC {
-            vc.embedFlutterView(flutterView)
+            vc.embedFlutter(flutterVC)
         }
     }
 
@@ -658,8 +671,10 @@ class CNNativeTabBarManager: NSObject {
                 unselectedTintColor = ImageUtils.colorFromARGB(unselTint)
             }
 
+            let topBadgeCounts = args["badgeCounts"] as? [Int?]
             enableNativeTabBar(
-                tabs: tabs, selectedIndex: selectedIndex, isDark: isDark, shrinkWhileScroll: shrink)
+                tabs: tabs, selectedIndex: selectedIndex, isDark: isDark, shrinkWhileScroll: shrink,
+                badgeCounts: topBadgeCounts)
             result(nil)
 
         case "disable":
@@ -730,6 +745,8 @@ class CNNativeTabBarManager: NSObject {
                         } else {
                             viewController.tabBarItem.badgeValue = nil
                         }
+                    } else {
+                        viewController.tabBarItem.badgeValue = nil
                     }
                 }
             }

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -57,7 +57,8 @@ class CNNativeTabBarManager: NSObject {
 
         // Try to find it from windows
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+            let window = windowScene.windows.first(where: { $0.isKeyWindow })
+        {
             if let flutterVC = window.rootViewController as? FlutterViewController {
                 self.flutterViewController = flutterVC
                 return flutterVC
@@ -151,14 +152,16 @@ class CNNativeTabBarManager: NSObject {
 
                 if let symbol = config.sfSymbol, !symbol.isEmpty {
                     if let unselTint = unselectedTintColor {
-                        image = UIImage(systemName: symbol)?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+                        image = UIImage(systemName: symbol)?.withTintColor(
+                            unselTint, renderingMode: .alwaysOriginal)
                     } else {
                         image = UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
                     }
                 }
 
                 if let activeSymbol = config.activeSfSymbol, !activeSymbol.isEmpty {
-                    selectedImage = UIImage(systemName: activeSymbol)?.withRenderingMode(.alwaysTemplate)
+                    selectedImage = UIImage(systemName: activeSymbol)?.withRenderingMode(
+                        .alwaysTemplate)
                 } else {
                     selectedImage = image
                 }
@@ -191,7 +194,8 @@ class CNNativeTabBarManager: NSObject {
 
         // Replace root view controller
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+            let window = windowScene.windows.first(where: { $0.isKeyWindow })
+        {
             // Snapshot Flutter's last rendered frame before we move it
             let snapshot = flutterVC.view.snapshotView(afterScreenUpdates: false)
 
@@ -207,10 +211,11 @@ class CNNativeTabBarManager: NSObject {
             // Embed Flutter now that layout bounds are resolved
             let selectedVC = viewControllers[selectedIndex]
             if let navController = selectedVC as? UINavigationController,
-               let rootVC = navController.topViewController as? FlutterTabViewController {
-                rootVC.embedFlutterView(flutterVC.view)
+                let rootVC = navController.topViewController as? FlutterTabViewController
+            {
+                rootVC.embedFlutter(flutterVC)
             } else if let flutterTabVC = selectedVC as? FlutterTabViewController {
-                flutterTabVC.embedFlutterView(flutterVC.view)
+                flutterTabVC.embedFlutter(flutterVC)
             }
 
             // Overlay snapshot to cover the brief gap before Flutter renders its first frame
@@ -233,7 +238,9 @@ class CNNativeTabBarManager: NSObject {
     private var ignoreInitialSearchUpdate = true
 
     /// Enable search-only mode (single search tab, no tab bar)
-    private func enableSearchOnlyMode(flutterVC: FlutterViewController, config: TabConfig, isDark: Bool) {
+    private func enableSearchOnlyMode(
+        flutterVC: FlutterViewController, config: TabConfig, isDark: Bool
+    ) {
         // Reset flag
         ignoreInitialSearchUpdate = true
 
@@ -269,11 +276,12 @@ class CNNativeTabBarManager: NSObject {
         self.searchOnlyNavController = navController
 
         // Embed Flutter view FIRST
-        searchVC.embedFlutterView(flutterVC.view)
+        searchVC.embedFlutter(flutterVC)
 
         // Replace root view controller
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+            let window = windowScene.windows.first(where: { $0.isKeyWindow })
+        {
             window.rootViewController = navController
             window.makeKeyAndVisible()
 
@@ -296,19 +304,22 @@ class CNNativeTabBarManager: NSObject {
 
         // Remove Flutter view from search-only nav controller if present
         if let navController = searchOnlyNavController,
-           let searchVC = navController.topViewController as? FlutterTabViewController {
+            let searchVC = navController.topViewController as? FlutterTabViewController
+        {
             searchVC.removeFlutterView()
         }
 
         // Remove Flutter view from tab if embedded
         if let tabBar = tabBarController,
-           let selectedVC = tabBar.selectedViewController as? FlutterTabViewController {
+            let selectedVC = tabBar.selectedViewController as? FlutterTabViewController
+        {
             selectedVC.removeFlutterView()
         }
 
         // Restore Flutter as root
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+            let window = windowScene.windows.first(where: { $0.isKeyWindow })
+        {
             UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
                 window.rootViewController = flutterVC
             }
@@ -333,12 +344,14 @@ class CNNativeTabBarManager: NSObject {
         methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
 
         guard let flutterView = flutterViewController?.view,
-              let tabBar = tabBarController else { return }
+            let tabBar = tabBarController
+        else { return }
 
         // Get the selected view controller - handle navigation controller wrapping for search tab
         var targetVC: FlutterTabViewController?
         if let navController = tabBar.selectedViewController as? UINavigationController,
-           let rootVC = navController.topViewController as? FlutterTabViewController {
+            let rootVC = navController.topViewController as? FlutterTabViewController
+        {
             targetVC = rootVC
         } else if let flutterTabVC = tabBar.selectedViewController as? FlutterTabViewController {
             targetVC = flutterTabVC
@@ -353,8 +366,10 @@ class CNNativeTabBarManager: NSObject {
         switch call.method {
         case "enable":
             guard let args = call.arguments as? [String: Any],
-                  let tabsData = args["tabs"] as? [[String: Any]] else {
-                result(FlutterError(code: "invalid_args", message: "Invalid tabs data", details: nil))
+                let tabsData = args["tabs"] as? [[String: Any]]
+            else {
+                result(
+                    FlutterError(code: "invalid_args", message: "Invalid tabs data", details: nil))
                 return
             }
 
@@ -364,7 +379,9 @@ class CNNativeTabBarManager: NSObject {
                 let activeSymbol = data["activeSfSymbol"] as? String
                 let isSearch = (data["isSearch"] as? Bool) ?? false
                 let badgeCount = data["badgeCount"] as? Int
-                return TabConfig(title: title, sfSymbol: symbol, activeSfSymbol: activeSymbol, isSearchTab: isSearch, badgeCount: badgeCount)
+                return TabConfig(
+                    title: title, sfSymbol: symbol, activeSfSymbol: activeSymbol,
+                    isSearchTab: isSearch, badgeCount: badgeCount)
             }
 
             let selectedIndex = (args["selectedIndex"] as? Int) ?? 0
@@ -387,7 +404,8 @@ class CNNativeTabBarManager: NSObject {
 
         case "setSelectedIndex":
             guard let args = call.arguments as? [String: Any],
-                  let index = args["index"] as? Int else {
+                let index = args["index"] as? Int
+            else {
                 result(FlutterError(code: "invalid_args", message: "Invalid index", details: nil))
                 return
             }
@@ -408,7 +426,8 @@ class CNNativeTabBarManager: NSObject {
 
         case "setSearchText":
             if let args = call.arguments as? [String: Any],
-               let text = args["text"] as? String {
+                let text = args["text"] as? String
+            {
                 searchController?.searchBar.text = text
             }
             result(nil)
@@ -418,8 +437,11 @@ class CNNativeTabBarManager: NSObject {
 
         case "setBadgeCounts":
             guard let args = call.arguments as? [String: Any],
-                  let badgeCounts = args["badgeCounts"] as? [Int?] else {
-                result(FlutterError(code: "invalid_args", message: "Invalid badge counts", details: nil))
+                let badgeCounts = args["badgeCounts"] as? [Int?]
+            else {
+                result(
+                    FlutterError(
+                        code: "invalid_args", message: "Invalid badge counts", details: nil))
                 return
             }
 
@@ -428,7 +450,8 @@ class CNNativeTabBarManager: NSObject {
                     if index < badgeCounts.count {
                         let count = badgeCounts[index]
                         if let count = count, count > 0 {
-                            viewController.tabBarItem.badgeValue = count > 99 ? "99+" : String(count)
+                            viewController.tabBarItem.badgeValue =
+                                count > 99 ? "99+" : String(count)
                         } else {
                             viewController.tabBarItem.badgeValue = nil
                         }
@@ -454,7 +477,8 @@ class CNNativeTabBarManager: NSObject {
 
         case "setBrightness":
             if let args = call.arguments as? [String: Any],
-               let isDark = args["isDark"] as? Bool {
+                let isDark = args["isDark"] as? Bool
+            {
                 tabBarController?.overrideUserInterfaceStyle = isDark ? .dark : .light
             }
             result(nil)
@@ -468,11 +492,13 @@ class CNNativeTabBarManager: NSObject {
 // MARK: - UITabBarControllerDelegate
 
 extension CNNativeTabBarManager: UITabBarControllerDelegate {
-    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+    func tabBarController(
+        _ tabBarController: UITabBarController, didSelect viewController: UIViewController
+    ) {
         let index = tabBarController.selectedIndex
         methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
 
-        guard let flutterView = flutterViewController?.view else { return }
+        guard let flutterVC = flutterViewController else { return }
 
         // Defer view-hierarchy changes so UIKit can finish its own tab transition first.
         // Moving Flutter's view synchronously inside didSelect interrupts the transition
@@ -481,12 +507,13 @@ extension CNNativeTabBarManager: UITabBarControllerDelegate {
             guard self != nil, let tabBar = tabBarController else { return }
             var target: FlutterTabViewController?
             if let nav = tabBar.selectedViewController as? UINavigationController,
-               let root = nav.topViewController as? FlutterTabViewController {
+                let root = nav.topViewController as? FlutterTabViewController
+            {
                 target = root
             } else if let vc = tabBar.selectedViewController as? FlutterTabViewController {
                 target = vc
             }
-            target?.embedFlutterView(flutterView)
+            target?.embedFlutter(flutterVC)
         }
     }
 }
@@ -563,7 +590,7 @@ private class FlutterTabViewController: UIViewController {
             flutterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             flutterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             flutterView.topAnchor.constraint(equalTo: view.topAnchor),
-            flutterView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            flutterView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
         embeddedFlutterView = flutterView
@@ -573,6 +600,29 @@ private class FlutterTabViewController: UIViewController {
         view.layoutIfNeeded()
 
         NSLog("✅ FlutterTabViewController: Embedded Flutter view, frame: \(flutterView.frame)")
+    }
+
+    /// Embeds a `FlutterViewController` as a child view controller, not just its
+    /// view. UIKit only delivers `viewWillAppear`/`viewDidAppear` to controllers
+    /// in the hierarchy, and the Flutter engine resumes its render loop in
+    /// response to those callbacks. Moving only the view leaves the controller
+    /// orphaned, which is why the engine sticks on its last frame (the splash)
+    /// until something else forces a re-layout (e.g. a tab tap).
+    func embedFlutter(_ flutterVC: FlutterViewController) {
+        // Detach from any previous parent.
+        if let oldParent = flutterVC.parent, oldParent !== self {
+            flutterVC.willMove(toParent: nil)
+            flutterVC.view.removeFromSuperview()
+            flutterVC.removeFromParent()
+        }
+
+        if flutterVC.parent !== self {
+            addChild(flutterVC)
+            embedFlutterView(flutterVC.view)
+            flutterVC.didMove(toParent: self)
+        } else {
+            embedFlutterView(flutterVC.view)
+        }
     }
 
     func removeFlutterView() {
@@ -604,7 +654,7 @@ private class SearchTabViewController: UIViewController {
             label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             label.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20)
+            label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20),
         ])
     }
 

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -30,6 +30,16 @@ class CNNativeTabBarManager: NSObject {
         let title: String
         let sfSymbol: String?
         let activeSfSymbol: String?
+        /// Custom icon sources, checked in this order: xcasset > raw bytes > Flutter asset path.
+        /// Any of these takes precedence over `sfSymbol`/`activeSfSymbol` when present.
+        let xcassetName: String?
+        let activeXcassetName: String?
+        let imageData: Data?
+        let activeImageData: Data?
+        let imageAssetPath: String?
+        let activeImageAssetPath: String?
+        let imageFormat: String?
+        let activeImageFormat: String?
         let isSearchTab: Bool
         let badgeCount: Int?
     }
@@ -160,24 +170,7 @@ class CNNativeTabBarManager: NSObject {
                 tabVC.methodChannel = self.methodChannel
 
                 // Setup tab bar item
-                var image: UIImage?
-                var selectedImage: UIImage?
-
-                if let symbol = config.sfSymbol, !symbol.isEmpty {
-                    if let unselTint = unselectedTintColor {
-                        image = UIImage(systemName: symbol)?.withTintColor(
-                            unselTint, renderingMode: .alwaysOriginal)
-                    } else {
-                        image = UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
-                    }
-                }
-
-                if let activeSymbol = config.activeSfSymbol, !activeSymbol.isEmpty {
-                    selectedImage = UIImage(systemName: activeSymbol)?.withRenderingMode(
-                        .alwaysTemplate)
-                } else {
-                    selectedImage = image
-                }
+                let (image, selectedImage) = icons(for: config)
 
                 tabVC.tabBarItem = UITabBarItem(
                     title: config.title,
@@ -413,58 +406,101 @@ class CNNativeTabBarManager: NSObject {
         }
     }
 
-    /// Composes an SF Symbol inside a tinted circle and returns the result as a
-    /// tab bar item image. Used to give icons a compact, circular silhouette
-    /// when the bar is shrunk.
+    /// Composes a glyph (custom image or SF Symbol) inside a tinted circle and
+    /// returns the result as a tab bar item image. Used to give icons a
+    /// compact, circular silhouette when the bar is shrunk.
     private func circularizedIcon(
-        symbolName: String,
+        image customImage: UIImage? = nil,
+        symbolName: String? = nil,
         tint: UIColor,
         background: UIColor,
         diameter: CGFloat = 30
     ) -> UIImage? {
         let size = CGSize(width: diameter, height: diameter)
+        let maxGlyphSize = diameter * 0.55
+
+        var glyph: UIImage?
+        if let customImage = customImage {
+            glyph = customImage.withTintColor(tint, renderingMode: .alwaysOriginal)
+        } else if let symbolName = symbolName {
+            let symbolConfig = UIImage.SymbolConfiguration(
+                pointSize: maxGlyphSize, weight: .semibold)
+            glyph = UIImage(systemName: symbolName, withConfiguration: symbolConfig)?
+                .withTintColor(tint, renderingMode: .alwaysOriginal)
+        }
+
         let renderer = UIGraphicsImageRenderer(size: size)
         let image = renderer.image { _ in
             background.setFill()
             UIBezierPath(ovalIn: CGRect(origin: .zero, size: size)).fill()
-            let config = UIImage.SymbolConfiguration(
-                pointSize: diameter * 0.55, weight: .semibold)
-            if let symbol = UIImage(systemName: symbolName, withConfiguration: config)?
-                .withTintColor(tint, renderingMode: .alwaysOriginal)
-            {
-                let symbolSize = symbol.size
-                let origin = CGPoint(
-                    x: (size.width - symbolSize.width) / 2,
-                    y: (size.height - symbolSize.height) / 2
-                )
-                symbol.draw(at: origin)
-            }
+
+            guard let glyph = glyph else { return }
+            let scale = min(
+                1, maxGlyphSize / max(glyph.size.width, 1),
+                maxGlyphSize / max(glyph.size.height, 1))
+            let glyphSize = CGSize(
+                width: glyph.size.width * scale, height: glyph.size.height * scale)
+            let origin = CGPoint(
+                x: (size.width - glyphSize.width) / 2,
+                y: (size.height - glyphSize.height) / 2
+            )
+            glyph.draw(in: CGRect(origin: origin, size: glyphSize))
         }
         return image.withRenderingMode(.alwaysOriginal)
     }
 
-    /// Rebuilds the regular (non-circular) image + selectedImage for a tab
-    /// using the original SF Symbol names and the configured tint colors.
-    private func originalIcons(for config: TabConfig) -> (UIImage?, UIImage?) {
-        var image: UIImage?
-        var selectedImage: UIImage?
+    /// Resolves a single tab bar icon image, preferring a custom source
+    /// (xcasset > raw bytes > Flutter asset path) over the SF Symbol
+    /// fallback. Pass a non-nil `tint` for `.alwaysOriginal` tinting, or `nil`
+    /// for `.alwaysTemplate` (system-tinted) rendering.
+    private func resolveIcon(
+        xcassetName: String?, imageData: Data?, imageAssetPath: String?, imageFormat: String?,
+        symbol: String?, tint: UIColor?, size: CGFloat = 24
+    ) -> UIImage? {
+        var raw: UIImage?
+        if let name = xcassetName, !name.isEmpty {
+            raw = UIImage(named: name, in: Bundle.main, compatibleWith: nil)
+        } else if let data = imageData {
+            raw = ImageUtils.createImageFromData(
+                data, format: imageFormat, size: CGSize(width: size, height: size))
+        } else if let path = imageAssetPath, !path.isEmpty {
+            raw = ImageUtils.loadFlutterAsset(
+                path, size: CGSize(width: size, height: size), format: imageFormat)
+        }
 
-        if let symbol = config.sfSymbol, !symbol.isEmpty {
-            if let unselTint = unselectedTintColor {
-                image = UIImage(systemName: symbol)?.withTintColor(
-                    unselTint, renderingMode: .alwaysOriginal)
-            } else {
-                image = UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
+        if let raw = raw {
+            if let tint = tint {
+                return raw.withTintColor(tint, renderingMode: .alwaysOriginal)
             }
+            return raw.withRenderingMode(.alwaysTemplate)
         }
 
-        if let activeSymbol = config.activeSfSymbol, !activeSymbol.isEmpty {
-            selectedImage = UIImage(systemName: activeSymbol)?
-                .withRenderingMode(.alwaysTemplate)
-        } else {
-            selectedImage = image
+        guard let symbol = symbol, !symbol.isEmpty else { return nil }
+        if let tint = tint {
+            return UIImage(systemName: symbol)?.withTintColor(tint, renderingMode: .alwaysOriginal)
         }
+        return UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
+    }
 
+    /// Builds the unselected/selected tab bar images for a config. The
+    /// selected image falls back to the unselected image when no active-state
+    /// icon is configured, mirroring the original SF-Symbol-only behavior.
+    private func icons(for config: TabConfig) -> (UIImage?, UIImage?) {
+        let image = resolveIcon(
+            xcassetName: config.xcassetName, imageData: config.imageData,
+            imageAssetPath: config.imageAssetPath, imageFormat: config.imageFormat,
+            symbol: config.sfSymbol, tint: unselectedTintColor)
+
+        let hasActiveIcon =
+            !(config.activeXcassetName ?? "").isEmpty || config.activeImageData != nil
+            || !(config.activeImageAssetPath ?? "").isEmpty
+            || !(config.activeSfSymbol ?? "").isEmpty
+        guard hasActiveIcon else { return (image, image) }
+
+        let selectedImage = resolveIcon(
+            xcassetName: config.activeXcassetName, imageData: config.activeImageData,
+            imageAssetPath: config.activeImageAssetPath, imageFormat: config.activeImageFormat,
+            symbol: config.activeSfSymbol, tint: nil)
         return (image, selectedImage)
     }
 
@@ -546,7 +582,16 @@ class CNNativeTabBarManager: NSObject {
                     item.title = nil
                     let tint = tintColor ?? .label
                     let background = (tintColor ?? UIColor.systemBlue).withAlphaComponent(0.18)
-                    if let symbol = config.sfSymbol, !symbol.isEmpty {
+                    let customImage = resolveIcon(
+                        xcassetName: config.xcassetName, imageData: config.imageData,
+                        imageAssetPath: config.imageAssetPath, imageFormat: config.imageFormat,
+                        symbol: nil, tint: nil)
+                    if let customImage = customImage {
+                        let circular = circularizedIcon(
+                            image: customImage, tint: tint, background: background)
+                        item.image = circular
+                        item.selectedImage = circular
+                    } else if let symbol = config.sfSymbol, !symbol.isEmpty {
                         let circular = circularizedIcon(
                             symbolName: symbol, tint: tint, background: background)
                         item.image = circular
@@ -554,7 +599,7 @@ class CNNativeTabBarManager: NSObject {
                     }
                 } else {
                     item.title = config.title
-                    let (image, selectedImage) = originalIcons(for: config)
+                    let (image, selectedImage) = icons(for: config)
                     item.image = image
                     item.selectedImage = selectedImage
                 }
@@ -650,10 +695,22 @@ class CNNativeTabBarManager: NSObject {
                 guard let title = data["title"] as? String else { return nil }
                 let symbol = data["sfSymbol"] as? String
                 let activeSymbol = data["activeSfSymbol"] as? String
+                let xcassetName = data["xcassetName"] as? String
+                let activeXcassetName = data["activeXcassetName"] as? String
+                let imageData = (data["imageData"] as? FlutterStandardTypedData)?.data
+                let activeImageData = (data["activeImageData"] as? FlutterStandardTypedData)?.data
+                let imageAssetPath = data["imageAssetPath"] as? String
+                let activeImageAssetPath = data["activeImageAssetPath"] as? String
+                let imageFormat = data["imageFormat"] as? String
+                let activeImageFormat = data["activeImageFormat"] as? String
                 let isSearch = (data["isSearch"] as? Bool) ?? false
                 let badgeCount = data["badgeCount"] as? Int
                 return TabConfig(
                     title: title, sfSymbol: symbol, activeSfSymbol: activeSymbol,
+                    xcassetName: xcassetName, activeXcassetName: activeXcassetName,
+                    imageData: imageData, activeImageData: activeImageData,
+                    imageAssetPath: imageAssetPath, activeImageAssetPath: activeImageAssetPath,
+                    imageFormat: imageFormat, activeImageFormat: activeImageFormat,
                     isSearchTab: isSearch, badgeCount: badgeCount)
             }
 

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -853,30 +853,39 @@ class CNNativeTabBarManager: NSObject {
 // MARK: - UITabBarControllerDelegate
 
 extension CNNativeTabBarManager: UITabBarControllerDelegate {
+    /// Re-parents the shared Flutter view into the *destination* tab before
+    /// UIKit's own selection transition begins. `shouldSelect` fires ahead of
+    /// any animation/highlight change, so the target already has Flutter
+    /// content by the time the transition renders — no gap where the empty
+    /// (clear-background) placeholder view is visible.
+    ///
+    /// Embedding used to happen in `didSelect`, deferred a runloop tick via
+    /// `DispatchQueue.main.async` because doing it synchronously there raced
+    /// UIKit's transition and made the bar need a second tap. That race is
+    /// what caused a flash of the empty tab before Flutter snapped back in;
+    /// doing the re-parent earlier (pre-transition) avoids both problems.
+    func tabBarController(
+        _ tabBarController: UITabBarController, shouldSelect viewController: UIViewController
+    ) -> Bool {
+        guard let flutterVC = flutterViewController else { return true }
+        var target: FlutterTabViewController?
+        if let nav = viewController as? UINavigationController,
+            let root = nav.topViewController as? FlutterTabViewController
+        {
+            target = root
+        } else if let vc = viewController as? FlutterTabViewController {
+            target = vc
+        }
+        target?.embedFlutter(flutterVC)
+        return true
+    }
+
     func tabBarController(
         _ tabBarController: UITabBarController, didSelect viewController: UIViewController
     ) {
         let index = tabBarController.selectedIndex
         showTabBarAnimated()
         methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
-
-        guard let flutterVC = flutterViewController else { return }
-
-        // Defer view-hierarchy changes so UIKit can finish its own tab transition first.
-        // Moving Flutter's view synchronously inside didSelect interrupts the transition
-        // animation and causes the tab bar to require a second tap before responding.
-        DispatchQueue.main.async { [weak self, weak tabBarController] in
-            guard self != nil, let tabBar = tabBarController else { return }
-            var target: FlutterTabViewController?
-            if let nav = tabBar.selectedViewController as? UINavigationController,
-                let root = nav.topViewController as? FlutterTabViewController
-            {
-                target = root
-            } else if let vc = tabBar.selectedViewController as? FlutterTabViewController {
-                target = vc
-            }
-            target?.embedFlutter(flutterVC)
-        }
     }
 }
 

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -22,6 +22,7 @@ class CNNativeTabBarManager: NSObject {
     private var shrinkOffset: CGFloat = 16
     private var lastScrollOffset: CGFloat = 0
     private var isTabBarShrunk: Bool = false
+    private var isRTL: Bool = false
     /// Raw string from Flutter, mapped to `UITabBarController.MinimizeBehavior`
     /// when applied: "never" | "onScrollDown" | "onScrollUp" | "automatic".
     private var minimizeBehaviorRaw: String = "automatic"
@@ -201,6 +202,7 @@ class CNNativeTabBarManager: NSObject {
         }
 
         tabBar.viewControllers = viewControllers
+        applyLayoutDirection(to: tabBar)
 
         // Apply tint colors
         if let tint = tintColor {
@@ -279,6 +281,8 @@ class CNNativeTabBarManager: NSObject {
         let navController = UINavigationController(rootViewController: searchVC)
         navController.navigationBar.prefersLargeTitles = true
         navController.overrideUserInterfaceStyle = isDark ? .dark : .light
+        navController.view.semanticContentAttribute = layoutDirection
+        navController.navigationBar.semanticContentAttribute = layoutDirection
 
         // Setup search controller - NOT active by default
         let search = UISearchController(searchResultsController: nil)
@@ -367,6 +371,27 @@ class CNNativeTabBarManager: NSObject {
         self.shrinkWhileScroll = false
         self.isTabBarShrunk = false
         NSLog("✅ CNNativeTabBarManager: Native tab bar disabled")
+    }
+
+    /// Mirrors layout (tab order, nav bar chevrons, etc.) to match the
+    /// Flutter app's text direction. `.unspecified` is intentionally not
+    /// used here — this always reflects an explicit choice from Flutter
+    /// rather than inheriting UIKit's own locale-based default.
+    private var layoutDirection: UISemanticContentAttribute {
+        isRTL ? .forceRightToLeft : .forceLeftToRight
+    }
+
+    /// Applies `layoutDirection` to a tab bar controller and its tab bar.
+    private func applyLayoutDirection(to tabBar: UITabBarController) {
+        let direction = layoutDirection
+        tabBar.view.semanticContentAttribute = direction
+        tabBar.tabBar.semanticContentAttribute = direction
+        for viewController in tabBar.viewControllers ?? [] {
+            viewController.view.semanticContentAttribute = direction
+            if let nav = viewController as? UINavigationController {
+                nav.navigationBar.semanticContentAttribute = direction
+            }
+        }
     }
 
     private func setupTabBarAppearance(_ tabBar: UITabBarController) {
@@ -719,6 +744,7 @@ class CNNativeTabBarManager: NSObject {
             let shrink = (args["shrinkWhileScroll"] as? Bool) ?? false
             self.shrinkOffset = CGFloat((args["shrinkOffset"] as? Double) ?? 16)
             self.minimizeBehaviorRaw = (args["minimizeBehavior"] as? String) ?? "automatic"
+            self.isRTL = (args["isRTL"] as? Bool) ?? false
 
             // Parse colors
             if let tint = args["tint"] as? Int {
@@ -829,6 +855,21 @@ class CNNativeTabBarManager: NSObject {
                 let isDark = args["isDark"] as? Bool
             {
                 tabBarController?.overrideUserInterfaceStyle = isDark ? .dark : .light
+            }
+            result(nil)
+
+        case "setTextDirection":
+            if let args = call.arguments as? [String: Any],
+                let rtl = args["isRTL"] as? Bool
+            {
+                self.isRTL = rtl
+                if let tabBar = tabBarController {
+                    applyLayoutDirection(to: tabBar)
+                }
+                if let navController = searchOnlyNavController {
+                    navController.view.semanticContentAttribute = layoutDirection
+                    navController.navigationBar.semanticContentAttribute = layoutDirection
+                }
             }
             result(nil)
 

--- a/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
+++ b/ios/cupertino_native_plus/Sources/cupertino_native_plus/Views/CNNativeTabBarManager.swift
@@ -18,6 +18,10 @@ class CNNativeTabBarManager: NSObject {
     private var isEnabled: Bool = false
     private var tintColor: UIColor?
     private var unselectedTintColor: UIColor?
+    private var shrinkWhileScroll: Bool = false
+    private var shrinkOffset: CGFloat = 16
+    private var lastScrollOffset: CGFloat = 0
+    private var isTabBarShrunk: Bool = false
 
     struct TabConfig {
         let title: String
@@ -71,7 +75,12 @@ class CNNativeTabBarManager: NSObject {
     private var searchOnlyNavController: UINavigationController?
 
     /// Enable native tab bar mode
-    private func enableNativeTabBar(tabs: [TabConfig], selectedIndex: Int, isDark: Bool) {
+    private func enableNativeTabBar(
+        tabs: [TabConfig], selectedIndex: Int, isDark: Bool, shrinkWhileScroll: Bool = false
+    ) {
+        self.shrinkWhileScroll = shrinkWhileScroll
+        self.lastScrollOffset = 0
+        self.isTabBarShrunk = false
         guard let flutterVC = getFlutterViewController() else {
             NSLog("❌ CNNativeTabBarManager: Could not find FlutterViewController")
             return
@@ -337,6 +346,8 @@ class CNNativeTabBarManager: NSObject {
 
         self.isEnabled = false
         self.tabBarController = nil
+        self.shrinkWhileScroll = false
+        self.isTabBarShrunk = false
         NSLog("✅ CNNativeTabBarManager: Native tab bar disabled")
     }
 
@@ -348,7 +359,83 @@ class CNNativeTabBarManager: NSObject {
         tabBar.tabBar.backgroundColor = .clear
     }
 
+    private func showTabBarAnimated() {
+        guard let tabBar = tabBarController, isTabBarShrunk else { return }
+        isTabBarShrunk = false
+        lastScrollOffset = 0
+        applyShrinkState(false, on: tabBar, duration: 0.3)
+    }
+
+    private func handleScrollOffset(_ offset: CGFloat) {
+        guard let tabBar = tabBarController else { return }
+
+        if offset <= 0 {
+            if isTabBarShrunk {
+                isTabBarShrunk = false
+                applyShrinkState(false, on: tabBar)
+            }
+            lastScrollOffset = offset
+            return
+        }
+
+        let delta = offset - lastScrollOffset
+        guard abs(delta) > 4 else { return }
+        lastScrollOffset = offset
+
+        if delta > 0 && !isTabBarShrunk {
+            isTabBarShrunk = true
+            applyShrinkState(true, on: tabBar)
+        } else if delta < 0 && isTabBarShrunk {
+            isTabBarShrunk = false
+            applyShrinkState(false, on: tabBar)
+        }
+    }
+
+    /// Toggles the shrunken state of the whole tab bar, scaling the entire bar
+    /// (including its glass background) and hiding the per-item labels so the
+    /// compact bar reads as a pill of icons. Labels are restored from
+    /// `tabConfigurations` when expanding.
+    private func applyShrinkState(
+        _ shrunk: Bool, on tabBar: UITabBarController, duration: TimeInterval = 0.25
+    ) {
+        // Anchor scaling to the bottom-center so the bar shrinks "into" the
+        // home-indicator area rather than drifting up from the screen edge.
+        tabBar.tabBar.layer.anchorPoint = CGPoint(x: 0.5, y: 1.0)
+        tabBar.tabBar.layer.position = CGPoint(
+            x: tabBar.tabBar.bounds.midX,
+            y: tabBar.tabBar.bounds.maxY
+        )
+
+        if let items = tabBar.tabBar.items {
+            for (index, item) in items.enumerated() {
+                if shrunk {
+                    item.title = nil
+                } else if index < tabConfigurations.count {
+                    item.title = tabConfigurations[index].title
+                }
+            }
+        }
+
+        UIView.animate(withDuration: duration) {
+            if shrunk {
+                // Convert a fixed point-based side margin into a scale factor so
+                // the shrunken bar pulls in by the same number of points on
+                // every screen size, rather than a fixed percentage that looks
+                // tiny on small phones and huge on larger ones.
+                let sideMargin: CGFloat = 24
+                let bottomInset: CGFloat = 8
+                let barWidth = max(tabBar.tabBar.bounds.width, 1)
+                let scale = max(0.5, (barWidth - 2 * sideMargin) / barWidth)
+                tabBar.tabBar.transform = CGAffineTransform(translationX: 0, y: -bottomInset)
+                    .scaledBy(x: scale, y: scale)
+            } else {
+                tabBar.tabBar.transform = .identity
+            }
+        }
+    }
+
     private func notifyTabSelected(_ index: Int) {
+        showTabBarAnimated()
         methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
 
         guard let flutterView = flutterViewController?.view,
@@ -394,6 +481,8 @@ class CNNativeTabBarManager: NSObject {
 
             let selectedIndex = (args["selectedIndex"] as? Int) ?? 0
             let isDark = (args["isDark"] as? Bool) ?? false
+            let shrink = (args["shrinkWhileScroll"] as? Bool) ?? false
+            self.shrinkOffset = CGFloat((args["shrinkOffset"] as? Double) ?? 16)
 
             // Parse colors
             if let tint = args["tint"] as? Int {
@@ -403,7 +492,8 @@ class CNNativeTabBarManager: NSObject {
                 unselectedTintColor = ImageUtils.colorFromARGB(unselTint)
             }
 
-            enableNativeTabBar(tabs: tabs, selectedIndex: selectedIndex, isDark: isDark)
+            enableNativeTabBar(
+                tabs: tabs, selectedIndex: selectedIndex, isDark: isDark, shrinkWhileScroll: shrink)
             result(nil)
 
         case "disable":
@@ -491,6 +581,15 @@ class CNNativeTabBarManager: NSObject {
             }
             result(nil)
 
+        case "updateScrollOffset":
+            if let args = call.arguments as? [String: Any],
+                let offset = args["offset"] as? Double,
+                shrinkWhileScroll
+            {
+                handleScrollOffset(CGFloat(offset))
+            }
+            result(nil)
+
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -504,6 +603,7 @@ extension CNNativeTabBarManager: UITabBarControllerDelegate {
         _ tabBarController: UITabBarController, didSelect viewController: UIViewController
     ) {
         let index = tabBarController.selectedIndex
+        showTabBarAnimated()
         methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
 
         guard let flutterVC = flutterViewController else { return }

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -60,6 +60,9 @@ class CNTabBarNative {
   /// UITabBarController. Your Flutter content will be displayed within
   /// the selected tab.
   ///
+  /// Pass [textDirection] (e.g. `Directionality.of(context)`) so the native
+  /// tab bar mirrors its layout for right-to-left locales.
+  ///
   /// Only works on iOS 26+. On older versions, this is a no-op.
   static Future<void> enable({
     required List<CNTab> tabs,
@@ -77,6 +80,7 @@ class CNTabBarNative {
     List<int?>? badgeCounts,
     CNTabBarMinimizeBehavior minimizeBehavior =
         CNTabBarMinimizeBehavior.automatic,
+    TextDirection textDirection = TextDirection.ltr,
   }) async {
     assert(
       badgeCounts == null || badgeCounts.length == tabs.length,
@@ -164,6 +168,7 @@ class CNTabBarNative {
       'shrinkOffset': shrinkOffset,
       'badgeCounts': badgeCounts,
       'minimizeBehavior': minimizeBehavior.rawValue,
+      'isRTL': textDirection == TextDirection.rtl,
       if (tintColor != null) 'tint': tintColor.toARGB32(),
       if (unselectedTintColor != null)
         'unselectedTint': unselectedTintColor.toARGB32(),
@@ -259,6 +264,18 @@ class CNTabBarNative {
   static Future<void> setBrightness({required bool isDark}) async {
     if (!_isEnabled) return;
     await _channel.invokeMethod('setBrightness', {'isDark': isDark});
+  }
+
+  /// Notifies the native tab bar of an app text-direction change.
+  ///
+  /// Call this when [Directionality.of(context)] changes (e.g. a locale
+  /// switch between LTR and RTL) if it was not already current in [enable].
+  /// No-op when the native tab bar is not enabled.
+  static Future<void> setTextDirection(TextDirection textDirection) async {
+    if (!_isEnabled) return;
+    await _channel.invokeMethod('setTextDirection', {
+      'isRTL': textDirection == TextDirection.rtl,
+    });
   }
 
   /// Updates the iOS 26 native `UITabBarController.tabBarMinimizeBehavior`.

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -71,6 +71,8 @@ class CNTabBarNative {
     Color? tintColor,
     Color? unselectedTintColor,
     bool? isDark,
+    bool shrinkWhileScroll = false,
+    double shrinkOffset = 16,
   }) async {
     // Only works on iOS 26+
     if (defaultTargetPlatform != TargetPlatform.iOS ||
@@ -107,6 +109,8 @@ class CNTabBarNative {
           .toList(),
       'selectedIndex': selectedIndex,
       'isDark': isDark ?? false,
+      'shrinkWhileScroll': shrinkWhileScroll,
+      'shrinkOffset': shrinkOffset,
       if (tintColor != null) 'tint': tintColor.toARGB32(),
       if (unselectedTintColor != null)
         'unselectedTint': unselectedTintColor.toARGB32(),
@@ -200,6 +204,19 @@ class CNTabBarNative {
   static Future<void> setBrightness({required bool isDark}) async {
     if (!_isEnabled) return;
     await _channel.invokeMethod('setBrightness', {'isDark': isDark});
+  }
+
+  /// Reports the current scroll offset so the native tab bar can shrink/expand.
+  ///
+  /// Call this inside a [ScrollController] listener or a
+  /// [NotificationListener<ScrollNotification>] when [shrinkWhileScroll] was
+  /// set to `true` in [enable]. The tab bar hides while scrolling down and
+  /// reappears when scrolling up or when the list is at the top.
+  ///
+  /// No-op when the native tab bar is not enabled.
+  static Future<void> reportScrollOffset(double offset) async {
+    if (!_isEnabled) return;
+    await _channel.invokeMethod('updateScrollOffset', {'offset': offset});
   }
 
   /// Returns `true` if the native tab bar is currently active on the platform side.

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -73,6 +73,9 @@ class CNTabBarNative {
     bool? isDark,
     bool shrinkWhileScroll = false,
     double shrinkOffset = 16,
+    List<int?>? badgeCounts,
+    CNTabBarMinimizeBehavior minimizeBehavior =
+        CNTabBarMinimizeBehavior.automatic,
   }) async {
     // Only works on iOS 26+
     if (defaultTargetPlatform != TargetPlatform.iOS ||
@@ -111,6 +114,8 @@ class CNTabBarNative {
       'isDark': isDark ?? false,
       'shrinkWhileScroll': shrinkWhileScroll,
       'shrinkOffset': shrinkOffset,
+      'badgeCounts': badgeCounts,
+      'minimizeBehavior': minimizeBehavior.rawValue,
       if (tintColor != null) 'tint': tintColor.toARGB32(),
       if (unselectedTintColor != null)
         'unselectedTint': unselectedTintColor.toARGB32(),
@@ -204,6 +209,19 @@ class CNTabBarNative {
   static Future<void> setBrightness({required bool isDark}) async {
     if (!_isEnabled) return;
     await _channel.invokeMethod('setBrightness', {'isDark': isDark});
+  }
+
+  /// Updates the iOS 26 native `UITabBarController.tabBarMinimizeBehavior`.
+  ///
+  /// Mirrors SwiftUI's `TabView.tabBarMinimizeBehavior(_:)`. No-op on iOS < 26.
+  /// No-op when the native tab bar is not enabled.
+  static Future<void> setMinimizeBehavior(
+    CNTabBarMinimizeBehavior behavior,
+  ) async {
+    if (!_isEnabled) return;
+    await _channel.invokeMethod('setMinimizeBehavior', {
+      'minimizeBehavior': behavior.rawValue,
+    });
   }
 
   /// Reports the current scroll offset so the native tab bar can shrink/expand.
@@ -311,4 +329,27 @@ class CNTab extends Equatable {
     isSearchTab,
     badgeCount,
   ];
+}
+
+/// Mirrors `UITabBarController.MinimizeBehavior` on iOS 26+.
+///
+/// Equivalent to the SwiftUI `TabBarMinimizeBehavior` values used by
+/// `TabView.tabBarMinimizeBehavior(_:)`.
+enum CNTabBarMinimizeBehavior {
+  /// Never minimize the tab bar.
+  never('never'),
+
+  /// Minimize the tab bar when the user scrolls down.
+  onScrollDown('onScrollDown'),
+
+  /// Minimize the tab bar when the user scrolls up.
+  onScrollUp('onScrollUp'),
+
+  /// System-chosen default minimization behavior.
+  automatic('automatic');
+
+  const CNTabBarMinimizeBehavior(this.rawValue);
+
+  /// Wire-format string sent to the iOS side.
+  final String rawValue;
 }

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 
 import '../channel/view_types.dart';
 import '../style/sf_symbol.dart';
+import '../utils/icon_renderer.dart';
 import '../utils/version_detector.dart';
 
 /// iOS 26+ Native Tab Bar with Search Support
@@ -101,19 +102,62 @@ class CNTabBarNative {
     // Setup method call handler for callbacks
     _channel.setMethodCallHandler(_handleMethodCall);
 
+    // Resolve Flutter asset paths for custom icons (skipped for xcasset
+    // entries, which the native side loads directly by name).
+    final imageAssetPaths = await Future.wait(
+      tabs.map((tab) async {
+        final icon = tab.icon;
+        if (icon == null ||
+            icon.assetPath.isEmpty ||
+            (icon.xcassetName ?? '').isNotEmpty) {
+          return '';
+        }
+        return resolveAssetPathForPixelRatio(icon.assetPath);
+      }),
+    );
+    final activeImageAssetPaths = await Future.wait(
+      tabs.map((tab) async {
+        final icon = tab.activeIcon;
+        if (icon == null ||
+            icon.assetPath.isEmpty ||
+            (icon.xcassetName ?? '').isNotEmpty) {
+          return '';
+        }
+        return resolveAssetPathForPixelRatio(icon.assetPath);
+      }),
+    );
+
     // Enable native tab bar
     await _channel.invokeMethod('enable', {
-      'tabs': tabs
-          .map(
-            (tab) => {
-              'title': tab.title,
-              'sfSymbol': tab.sfSymbol?.name,
-              'activeSfSymbol': tab.activeSfSymbol?.name,
-              'isSearch': tab.isSearchTab,
-              'badgeCount': tab.badgeCount,
-            },
-          )
-          .toList(),
+      'tabs': [
+        for (var i = 0; i < tabs.length; i++)
+          {
+            'title': tabs[i].title,
+            'sfSymbol':
+                tabs[i].icon?.toMap()['iconName'] as String? ??
+                tabs[i].sfSymbol?.name,
+            'activeSfSymbol':
+                tabs[i].activeIcon?.toMap()['iconName'] as String? ??
+                tabs[i].activeSfSymbol?.name,
+            'xcassetName': tabs[i].icon?.xcassetName ?? '',
+            'activeXcassetName': tabs[i].activeIcon?.xcassetName ?? '',
+            'imageAssetPath': imageAssetPaths[i],
+            'activeImageAssetPath': activeImageAssetPaths[i],
+            'imageData': tabs[i].icon?.imageData,
+            'activeImageData': tabs[i].activeIcon?.imageData,
+            'imageFormat':
+                tabs[i].icon?.imageFormat ??
+                detectImageFormat(imageAssetPaths[i], tabs[i].icon?.imageData),
+            'activeImageFormat':
+                tabs[i].activeIcon?.imageFormat ??
+                detectImageFormat(
+                  activeImageAssetPaths[i],
+                  tabs[i].activeIcon?.imageData,
+                ),
+            'isSearch': tabs[i].isSearchTab,
+            'badgeCount': tabs[i].badgeCount,
+          },
+      ],
       'selectedIndex': selectedIndex,
       'isDark': isDark ?? false,
       'shrinkWhileScroll': shrinkWhileScroll,
@@ -297,7 +341,7 @@ class CNTabBarNative {
 
 /// Configuration for a native tab in [CNTabBarNative].
 ///
-/// Each tab can have a title, SF Symbol icon, and optionally be marked as a search tab.
+/// Each tab can have a title, an icon, and optionally be marked as a search tab.
 ///
 /// Example:
 /// ```dart
@@ -305,18 +349,38 @@ class CNTabBarNative {
 ///   title: 'Home',
 ///   sfSymbol: CNSymbol('house.fill'),
 /// )
+///
+/// // Custom artwork instead of an SF Symbol:
+/// CNTab(
+///   title: 'Home',
+///   icon: CNIcon.asset('assets/icons/home.svg'),
+/// )
 /// ```
 class CNTab extends Equatable {
   /// Title shown below the tab icon.
   final String title;
 
   /// SF Symbol for the unselected state.
+  ///
+  /// Ignored when [icon] is provided.
   final CNSymbol? sfSymbol;
 
   /// SF Symbol for the selected state.
   ///
-  /// Falls back to [sfSymbol] when not provided.
+  /// Falls back to [sfSymbol] when not provided. Ignored when [activeIcon]
+  /// (or [icon], as its fallback) is provided.
   final CNSymbol? activeSfSymbol;
+
+  /// Custom icon for the unselected state — takes precedence over [sfSymbol].
+  ///
+  /// Accepts any [CNIcon] source: [CNIcon.asset] (Flutter asset path, format
+  /// auto-detected), [CNIcon.svg]/[CNIcon.png]/[CNIcon.jpg] (raw bytes), or
+  /// [CNIcon.xcasset] (app bundle asset catalog).
+  final CNIcon? icon;
+
+  /// Custom icon for the selected state — takes precedence over
+  /// [activeSfSymbol]. Falls back to [icon] when not provided.
+  final CNIcon? activeIcon;
 
   /// Whether this tab triggers the iOS 26 native search bar.
   ///
@@ -332,6 +396,8 @@ class CNTab extends Equatable {
     required this.title,
     this.sfSymbol,
     this.activeSfSymbol,
+    this.icon,
+    this.activeIcon,
     this.isSearchTab = false,
     this.badgeCount,
   });
@@ -341,6 +407,8 @@ class CNTab extends Equatable {
     title,
     sfSymbol,
     activeSfSymbol,
+    icon,
+    activeIcon,
     isSearchTab,
     badgeCount,
   ];

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -131,9 +131,11 @@ class CNTabBarNative {
   /// Disables the native tab bar and restores Flutter-only mode.
   ///
   /// Call this in [State.dispose] of the widget that called [enable].
-  /// No-op when the native tab bar is not already enabled.
-  static Future<void> disable() async {
-    if (!_isEnabled) {
+  /// No-op when the native tab bar is not already enabled, unless
+  /// [forceDisable] is `true`, which sends the disable call regardless
+  /// of tracked state (useful to recover from a desynced [_isEnabled] flag).
+  static Future<void> disable({bool forceDisable = false}) async {
+    if (!_isEnabled && !forceDisable) {
       return;
     }
 

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -77,6 +77,10 @@ class CNTabBarNative {
     CNTabBarMinimizeBehavior minimizeBehavior =
         CNTabBarMinimizeBehavior.automatic,
   }) async {
+    assert(
+      badgeCounts == null || badgeCounts.length == tabs.length,
+      'badgeCounts.length must match tabs.length',
+    );
     // Only works on iOS 26+
     if (defaultTargetPlatform != TargetPlatform.iOS ||
         !PlatformVersion.shouldUseNativeGlass) {
@@ -224,6 +228,9 @@ class CNTabBarNative {
     });
   }
 
+  static double _lastSentOffset = 0;
+  static int _lastSentTimestampMs = 0;
+
   /// Reports the current scroll offset so the native tab bar can shrink/expand.
   ///
   /// Call this inside a [ScrollController] listener or a
@@ -234,6 +241,12 @@ class CNTabBarNative {
   /// No-op when the native tab bar is not enabled.
   static Future<void> reportScrollOffset(double offset) async {
     if (!_isEnabled) return;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final deltaAbs = (offset - _lastSentOffset).abs();
+    final elapsedMs = nowMs - _lastSentTimestampMs;
+    if (deltaAbs < 4 && elapsedMs < 33) return;
+    _lastSentOffset = offset;
+    _lastSentTimestampMs = nowMs;
     await _channel.invokeMethod('updateScrollOffset', {'offset': offset});
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
 
 environment:
   sdk: ^3.9.0
-  flutter: '>=3.3.0'
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
@@ -24,7 +24,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
- add support for shrinking tab bar while scrolling
Adds a shrink-on-scroll behavior for the native tab bar. When enabled, the bar compresses into a pill of icons while scrolling down and expands back when scrolling up or reaching the top. Four new state variables track the shrink state and scroll position. New methods handleScrollOffset(_:) and applyShrinkState(_:on:duration:) drive the animation using CGAffineTransform anchored to the bottom-center so the bar shrinks toward the home indicator. A new "updateScrollOffset" method channel case receives scroll events from Flutter, and the Dart side gains shrinkWhileScroll/shrinkOffset params on enable() plus a new static reportScrollOffset(double) method.

- fix: ensure Flutter receives tab selection updates and improve view embedding transitions
Fixes two bugs where Flutter wasn't notified of the initially selected tab and the Flutter engine would stall on its last rendered frame when re-embedded. UITabBarController does not fire the delegate on programmatic initial selection, so "onTabSelected" is now fired manually after setup. The embedFlutter(_:) method now brackets detach and re-attach with beginAppearanceTransition/endAppearanceTransition, ensuring the Flutter engine receives the viewWillAppear/viewDidAppear lifecycle events it waits for before resuming rendering.

- fix: improve code readability and structure in CNNativeTabBarManager
A pure structural refactor with no behavior changes. Long guard let/if let chains are reformatted to Swift multi-line style with the closing brace on its own line. Long method signatures, TabConfig(...) initializers, FlutterError(...) constructions, and badge string logic are all wrapped to avoid overlong lines. All call sites of embedFlutterView(_:) are replaced with the new embedFlutter(_:), which embeds the controller into the hierarchy rather than just its view. A doc comment is added explaining why moving only the view is insufficient — the Flutter engine waits for viewWillAppear/viewDidAppear, which UIKit only delivers to controllers in the hierarchy.

- feat: enhance tab bar transition and selection handling for smoother UX
Overhauled the tab bar setup order and tab-switch behavior to fix a visual flash and a double-tap bug. selectedIndex and delegate are now assigned after window.rootViewController = tabBar because UITabBarController silently resets selectedIndex to 0 if set before entering a window. A snapshot of Flutter's last frame is captured before the transition and overlaid on the window, then faded out after a short delay to mask the blank gap before Flutter renders its first frame. Tab switches now defer view-hierarchy changes to DispatchQueue.main.async — moving Flutter's view synchronously inside didSelect was interrupting UIKit's animation and requiring a second tap to respond. The selected index is also read from tabBarController.selectedIndex instead of the fragile firstIndex(of:) approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS 26+ “shrink while scrolling” for the native tab bar, configurable via shrink offset, with scroll offset reporting.
  * Added minimize behavior control, per-tab badge counts, and support for custom tab icons (including active icons).
  * New APIs to set minimize behavior and report scroll offsets.
* **Bug Fixes / Improvements**
  * Improved native tab embedding and initial rendering behavior (including search-only mode), with smoother tab switching.
  * Enhanced native disable behavior with full teardown/reset; tab selection updates now stay in sync.
* **Chores**
  * Updated Flutter lint rules and added local Claude command permissions configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->