### PR TITLE
fix(tab_bar): fire onTap when the selected tab is reselected

### DIFF
--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -651,7 +651,12 @@ class _CNTabBarState extends State<CNTabBar> {
         if (isRightButton) {
           // Button mode: always fire callback, don't update _lastIndex
           widget.onTap(idx);
-        } else if (idx != _lastIndex) {
+        } else {
+          // Fire onTap even when the already-selected tab is tapped again,
+          // so consumers can react to reselection (e.g. pop a navigator to
+          // its root). Native only emits valueChanged for genuine user taps;
+          // programmatic selection is suppressed via
+          // suppressSelectionCallbacks, so this never fires spuriously.
           widget.onTap(idx);
           _lastIndex = idx;
         }


### PR DESCRIPTION
## Problem

`CNTabBar` swallows the *reselect* event. Tapping the tab that is already
selected does nothing, because the `valueChanged` handler bails out at:

```dart
} else if (idx != _lastIndex) {
  widget.onTap(idx);
  _lastIndex = idx;
}
```

Since `idx == _lastIndex` on reselect, `onTap` never fires. This breaks a
very common navigation pattern: tapping the current tab again to pop that
tab's navigation stack back to its root.

The native side already emits `valueChanged` for reselection, so the Dart
guard is the only thing dropping it.

## Fix

Always fire `widget.onTap(idx)` for tab taps (the non-button branch):

```dart
} else {
  widget.onTap(idx);
  _lastIndex = idx;
}
```

Programmatic selection is already suppressed natively via
`suppressSelectionCallbacks`, so `onTap` only fires for genuine user taps
and never fires spuriously. Button-mode taps are unaffected (handled in the
`isRightButton` branch above).

Fixes #20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tab taps now behave more consistently, including when reselecting the currently active tab.
  * Tabs on the right-side button area continue to trigger tap actions without changing the selected tab state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->