### PR TITLE
feat(tab_bar): optional placeholder while awaiting the native platform view

### DIFF
--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -116,6 +116,7 @@ class CNTabBar extends StatefulWidget {
     this.searchController,
     this.labelStyle,
     this.activeLabelStyle,
+    this.placeholder,
   }) : assert(items.length >= 2, 'Tab bar must have at least 2 items'),
        assert(
          items.length <= 5,
@@ -211,6 +212,19 @@ class CNTabBar extends StatefulWidget {
   /// On macOS (NSSegmentedControl-based tab bar), per-state label styling
   /// is not supported — font is applied to all states.
   final TextStyle? activeLabelStyle;
+
+  /// Widget shown instead of the Flutter fallback while the native platform
+  /// view is not yet available (startup / hot-restart guard).
+  ///
+  /// Only used on platforms that will eventually render the native tab bar
+  /// (iOS/macOS 26+). On platforms where the Flutter fallback is the
+  /// permanent UI (e.g. iOS < 26, Android), this is ignored and the fallback
+  /// is shown as usual.
+  ///
+  /// Useful to avoid a visible style flash between the Flutter fallback and
+  /// the native Liquid Glass bar — e.g. pass a [SizedBox] to reserve the
+  /// bar's space without drawing anything.
+  final Widget? placeholder;
 
   @override
   State<CNTabBar> createState() => _CNTabBarState();
@@ -363,6 +377,13 @@ class _CNTabBarState extends State<CNTabBar> {
 
     // Fallback to Flutter widgets for non-iOS/macOS, iOS/macOS < 26, or while guard is not ready
     if (!shouldUseNative) {
+      // When the native bar is coming (right platform/version, guard just not
+      // ready yet), let callers swap the transient fallback for a placeholder.
+      final nativeWillBeUsed =
+          isIOSOrMacOS && PlatformVersion.shouldUseNativeGlass;
+      if (nativeWillBeUsed && widget.placeholder != null) {
+        return widget.placeholder!;
+      }
       return _buildFlutterFallback(context);
     }
 


### PR DESCRIPTION
While `PlatformViewGuard` is not ready (startup / hot-restart guard), `CNTabBar` renders its Flutter fallback. On platforms that will render the native Liquid Glass bar, this produces a visible style flash: the CupertinoTabBar-style fallback appears for ~500ms, then swaps to the native bar with a completely different look.

This adds an optional `placeholder` widget used **instead of the Flutter fallback only during that transient window** — gated on `isIOSOrMacOS && PlatformVersion.shouldUseNativeGlass`, so on platforms where the fallback is the permanent UI (iOS < 26, Android) it is ignored and nothing changes. Defaults to `null`, preserving current behavior for all existing callers.

Example:
```dart
CNTabBar(
  items: [...],
  currentIndex: index,
  onTap: onTap,
  // Reserve the bar's space without drawing anything until the
  // native bar is ready.
  placeholder: const SizedBox(height: 50, width: double.infinity),
)
```

Related to #23 (both improve the cold-start experience of the tab bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional placeholder for the tab bar while the native version is preparing to load.
  * On iOS/macOS, users may now see a custom interim widget instead of the default fallback UI during this short transition.
  * Existing native and fallback behavior remains unchanged outside this loading window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->